### PR TITLE
fix: auto scroll to bottom

### DIFF
--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -1,10 +1,13 @@
 abstract final class GithubId {
+  /// Sorted by name
   static const participants = {
-    'luoxiashen',
-    'SeaHI-Robot',
-    'Http-200',
-    'bxoooooo',
     'Annalasu',
+    'bxoooooo',
+    'CHEN1016',
+    'Http-200',
+    'luoxiashen',
+    'Mgrsc',
+    'SeaHI-Robot',
   };
 
   static const contributors = {

--- a/lib/view/page/home/ctrl.dart
+++ b/lib/view/page/home/ctrl.dart
@@ -471,12 +471,13 @@ void _onTapEditMsg(BuildContext context, ChatHistoryItem chatItem) async {
 
 void _autoScroll(String chatId) {
   if (Stores.setting.scrollBottom.fetch()) {
-    // Only scroll to bottom when current chat is the working chat
-    final isWorking = chatId == _curChatId;
-    final isSubscribed = _loadingChatIds.contains(chatId);
-    if (isWorking && isSubscribed) {
-      _scrollBottom();
-    }
+    Funcs.throttle(() {
+      // Only scroll to bottom when current chat is the working chat
+      final isCurrentChat = chatId == _curChatId;
+      if (isCurrentChat) {
+        _scrollBottom();
+      }
+    }, id: 'autoScroll', duration: 100);
   }
 }
 

--- a/lib/view/page/home/req.dart
+++ b/lib/view/page/home/req.dart
@@ -112,6 +112,7 @@ Future<void> _onCreateText(
   _genChatTitle(context, chatId, config);
   _inputCtrl.clear();
   _chatRN.notify();
+  _loadingChatIds.add(chatId);
   _autoScroll(chatId);
 
   final useTools = OpenAICfg.canUseToolNow;
@@ -217,6 +218,7 @@ Future<void> _onCreateText(
           profileId: config.id,
         );
         _onStopStreamSub(chatId);
+        _loadingChatIds.remove(chatId);
         _loadingChatIds.remove(assistReply.id);
         _loadingChatIdRN.notify();
         // Wait for db to store the chat
@@ -226,6 +228,7 @@ Future<void> _onCreateText(
     );
   } catch (e, s) {
     _onErr(e, s, chatId, 'Listen text stream');
+    _loadingChatIds.remove(chatId);
   }
 }
 

--- a/lib/view/page/profile.dart
+++ b/lib/view/page/profile.dart
@@ -5,6 +5,7 @@ import 'package:gpt_box/data/model/chat/config.dart';
 import 'package:gpt_box/data/res/l10n.dart';
 import 'package:gpt_box/data/res/openai.dart';
 import 'package:gpt_box/data/store/all.dart';
+import 'package:icons_plus/icons_plus.dart';
 
 final class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key, Never? args});
@@ -69,10 +70,9 @@ final class _ProfilePageState extends State<ProfilePage> {
           trailing: val.loading
               ? UIs.centerSizedLoadingSmall
               : IconButton(
-                  onPressed: () {
-                    ApiBalance.refresh();
-                  },
-                  icon: const Icon(Icons.refresh)),
+                  onPressed: () => ApiBalance.refresh(),
+                  icon: const Icon(Icons.refresh),
+                ),
         ).cardx;
       },
     );
@@ -113,34 +113,15 @@ final class _ProfilePageState extends State<ProfilePage> {
     return ListTile(
       leading: const Icon(Icons.switch_account),
       title: Text(l10n.profile),
-      subtitle: Text(
-        '${cfg.displayName}, ${l10n.clickSwitch}',
-        style: UIs.textGrey,
-      ),
-      onTap: () async {
-        final vals = Stores.config.box
-            .toJson<ChatConfig>(includeInternal: false)
-            .values
-            .toList();
-        final newCfg = await context.showPickSingleDialog(
-          items: vals,
-          initial: cfg,
-          title: l10n.profile,
-          name: (p0) => p0.displayName,
-        );
-
-        if (newCfg == null) return;
-        OpenAICfg.setTo(newCfg);
-        _cfgRN.notify();
-      },
+      subtitle: Text(cfg.displayName, style: UIs.textGrey),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           // Delete
           if (cfg.id != ChatConfig.defaultId)
-            IconButton(
-              icon: const Icon(Icons.delete),
-              onPressed: () {
+            IconBtn(
+              icon: Icons.delete,
+              onTap: () {
                 if (cfg.id == ChatConfig.defaultId) return;
                 context.showRoundDialog(
                   title: l10n.attention,
@@ -161,9 +142,9 @@ final class _ProfilePageState extends State<ProfilePage> {
               },
             ),
           // Rename
-          IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () {
+          IconBtn(
+            icon: Icons.edit,
+            onTap: () {
               final ctrl = TextEditingController(text: cfg.name);
               context.showRoundDialog(
                 title: l10n.edit,
@@ -180,6 +161,26 @@ final class _ProfilePageState extends State<ProfilePage> {
                   },
                 ),
               );
+            },
+          ),
+          // Switch
+          IconBtn(
+            icon: OctIcons.arrow_switch,
+            onTap: () async {
+              final vals = Stores.config.box
+                  .toJson<ChatConfig>(includeInternal: false)
+                  .values
+                  .toList();
+              final newCfg = await context.showPickSingleDialog(
+                items: vals,
+                initial: cfg,
+                title: l10n.profile,
+                name: (p0) => p0.displayName,
+              );
+
+              if (newCfg == null) return;
+              OpenAICfg.setTo(newCfg);
+              _cfgRN.notify();
             },
           ),
         ],


### PR DESCRIPTION
Fixes #91

(By Github Copilot) This pull request fixes the bug where the auto scroll to bottom feature is not working. The issue was caused by the `_autoScroll` function not being called correctly. The fix ensures that the function is called only when the current chat is the working chat. Additionally, the loading chat ID is added and removed appropriately to prevent multiple scroll actions.