### PR TITLE
fix: raw md page has no titlebar on macOS

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -72,7 +72,8 @@ import 'l10n_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -80,7 +81,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -92,7 +94,8 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -921,7 +924,8 @@ abstract class AppLocalizations {
   String get wrap;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -930,44 +934,69 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'fr', 'id', 'ja', 'nl', 'pt', 'ru', 'tr', 'uk', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+        'de',
+        'en',
+        'es',
+        'fr',
+        'id',
+        'ja',
+        'nl',
+        'pt',
+        'ru',
+        'tr',
+        'uk',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'zh': {
-  switch (locale.countryCode) {
-    case 'TW': return AppLocalizationsZhTw();
-   }
-  break;
-   }
+    case 'zh':
+      {
+        switch (locale.countryCode) {
+          case 'TW':
+            return AppLocalizationsZhTw();
+        }
+        break;
+      }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de': return AppLocalizationsDe();
-    case 'en': return AppLocalizationsEn();
-    case 'es': return AppLocalizationsEs();
-    case 'fr': return AppLocalizationsFr();
-    case 'id': return AppLocalizationsId();
-    case 'ja': return AppLocalizationsJa();
-    case 'nl': return AppLocalizationsNl();
-    case 'pt': return AppLocalizationsPt();
-    case 'ru': return AppLocalizationsRu();
-    case 'tr': return AppLocalizationsTr();
-    case 'uk': return AppLocalizationsUk();
-    case 'zh': return AppLocalizationsZh();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'id':
+      return AppLocalizationsId();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'nl':
+      return AppLocalizationsNl();
+    case 'pt':
+      return AppLocalizationsPt();
+    case 'ru':
+      return AppLocalizationsRu();
+    case 'tr':
+      return AppLocalizationsTr();
+    case 'uk':
+      return AppLocalizationsUk();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Ähnlich wie https://api.openai.com/v1 (mit dem abschließenden /v1). Soll diese URL weiterhin verwendet werden?';
+  String get apiUrlV1Tip =>
+      'Ähnlich wie https://api.openai.com/v1 (mit dem abschließenden /v1). Soll diese URL weiterhin verwendet werden?';
 
   @override
   String get assistant => 'Assistent';
@@ -31,7 +34,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoScrollBottom => 'Automatisch nach unten scrollen';
 
   @override
-  String get backupTip => 'Bitte stellen Sie sicher, dass Ihre Sicherungsdatei privat und sicher ist!';
+  String get backupTip =>
+      'Bitte stellen Sie sicher, dass Ihre Sicherungsdatei privat und sicher ist!';
 
   @override
   String get balance => 'Guthaben';
@@ -40,7 +44,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get calcTokenLen => 'Token-Länge berechnen';
 
   @override
-  String get changeModelTip => 'Verschiedene Schlüssel können möglicherweise auf unterschiedliche Modelllisten zugreifen. Wenn Sie den Mechanismus nicht verstehen und Fehler auftreten, empfiehlt es sich, das Modell neu einzustellen.';
+  String get changeModelTip =>
+      'Verschiedene Schlüssel können möglicherweise auf unterschiedliche Modelllisten zugreifen. Wenn Sie den Mechanismus nicht verstehen und Fehler auftreten, empfiehlt es sich, das Modell neu einzustellen.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +118,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get emptyTrash => 'Papierkorb leeren';
 
   @override
-  String get emptyTrashTip => '==0, beim nächsten Start löschen. <0 nicht automatisch löschen.';
+  String get emptyTrashTip =>
+      '==0, beim nächsten Start löschen. <0 nicht automatisch löschen.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get headTailMode => 'Kopf-Schwanz-Modus';
 
   @override
-  String get headTailModeTip => 'Sendet nur `Prompt + erste Benutzernachricht + aktuelle Eingabe` als Kontext.\n\nDies ist besonders nützlich für die Übersetzung von Gesprächen (spart Tokens).';
+  String get headTailModeTip =>
+      'Sendet nur `Prompt + erste Benutzernachricht + aktuelle Eingabe` als Kontext.\n\nDies ist besonders nützlich für die Übersetzung von Gesprächen (spart Tokens).';
 
   @override
   String get help => 'Hilfe';
@@ -223,7 +230,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get message => 'Nachricht';
 
   @override
-  String get migrationV1UrlTip => 'Soll \"/v1\" automatisch am Ende der Konfiguration hinzugefügt werden?';
+  String get migrationV1UrlTip =>
+      'Soll \"/v1\" automatisch am Ende der Konfiguration hinzugefügt werden?';
 
   @override
   String get minute => 'Minute';
@@ -232,7 +240,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get model => 'Modell';
 
   @override
-  String get modelRegExpTip => 'Wenn der Modellname übereinstimmt, werden Tools verwendet';
+  String get modelRegExpTip =>
+      'Wenn der Modellname übereinstimmt, werden Tools verwendet';
 
   @override
   String get more => 'Mehr';
@@ -267,7 +276,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get onSwitchChat => 'Beim Wechseln der Konversation';
 
   @override
-  String get onlyRestoreHistory => 'Nur Chat-Verlauf wiederherstellen (API-URL und geheimer Schlüssel werden nicht wiederhergestellt)';
+  String get onlyRestoreHistory =>
+      'Nur Chat-Verlauf wiederherstellen (API-URL und geheimer Schlüssel werden nicht wiederhergestellt)';
 
   @override
   String get onlySyncOnLaunch => 'Nur beim Start synchronisieren';
@@ -294,7 +304,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip => 'Öffnen Sie diesen Link auf einem anderen Gerät, um die aktuelle Konfiguration schnell zu importieren.';
+  String get quickShareTip =>
+      'Öffnen Sie diesen Link auf einem anderen Gerät, um die aktuelle Konfiguration schnell zu importieren.';
 
   @override
   String get raw => 'Roh';
@@ -315,7 +326,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get replay => 'Wiederholen';
 
   @override
-  String get replayTip => 'Die wiederholten Nachrichten und alle folgenden Nachrichten werden gelöscht.';
+  String get replayTip =>
+      'Die wiederholten Nachrichten und alle folgenden Nachrichten werden gelöscht.';
 
   @override
   String get res => 'Ressource';
@@ -343,7 +355,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get saveErrChat => 'Fehlerhaften Chat speichern';
 
   @override
-  String get saveErrChatTip => 'Speichern Sie nach dem Empfangen/Senden jeder Nachricht, auch wenn Fehler auftreten';
+  String get saveErrChatTip =>
+      'Speichern Sie nach dem Empfangen/Senden jeder Nachricht, auch wenn Fehler auftreten';
 
   @override
   String get scrollSwitchChat => 'Scrollen zum Wechseln des Chats';
@@ -361,7 +374,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareFrom => 'Geteilt von';
 
   @override
-  String get skipSameTitle => 'Chats mit demselben Titel wie lokale Chats überspringen';
+  String get skipSameTitle =>
+      'Chats mit demselben Titel wie lokale Chats überspringen';
 
   @override
   String get softWrap => 'Zeilenumbruch';

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Similar to https://api.openai.com/v1 (requiring the final /v1). Continue using this URL?';
+  String get apiUrlV1Tip =>
+      'Similar to https://api.openai.com/v1 (requiring the final /v1). Continue using this URL?';
 
   @override
   String get assistant => 'Assistant';
@@ -40,7 +43,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calcTokenLen => 'Calculate tokens length';
 
   @override
-  String get changeModelTip => 'Different keys may be able to access different lists of models, so if you don\'t understand the mechanism and get an error, it is recommended to reset the model.';
+  String get changeModelTip =>
+      'Different keys may be able to access different lists of models, so if you don\'t understand the mechanism and get an error, it is recommended to reset the model.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +117,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emptyTrash => 'Empty recycle bin';
 
   @override
-  String get emptyTrashTip => '==0, delete on next startup. <0 do not delete automatically.';
+  String get emptyTrashTip =>
+      '==0, delete on next startup. <0 do not delete automatically.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +152,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get headTailMode => 'Head-Tail';
 
   @override
-  String get headTailModeTip => 'Only send `prompt + first user message + current input` as the context. \n\nThis is useful for translating as it saves tokens.';
+  String get headTailModeTip =>
+      'Only send `prompt + first user message + current input` as the context. \n\nThis is useful for translating as it saves tokens.';
 
   @override
   String get help => 'Help';
@@ -223,7 +229,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get message => 'Message';
 
   @override
-  String get migrationV1UrlTip => 'Should \"/v1\" be automatically added to the end of the configuration?';
+  String get migrationV1UrlTip =>
+      'Should \"/v1\" be automatically added to the end of the configuration?';
 
   @override
   String get minute => 'min';
@@ -267,7 +274,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onSwitchChat => 'When switching conversations';
 
   @override
-  String get onlyRestoreHistory => 'Only restore histories (exclude api url / secret key)';
+  String get onlyRestoreHistory =>
+      'Only restore histories (exclude api url / secret key)';
 
   @override
   String get onlySyncOnLaunch => 'Only sync on launch';
@@ -294,7 +302,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip => 'Open this link on another device to quickly import the current configuration.';
+  String get quickShareTip =>
+      'Open this link on another device to quickly import the current configuration.';
 
   @override
   String get raw => 'Raw';
@@ -315,7 +324,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get replay => 'Replay';
 
   @override
-  String get replayTip => 'The replayed messages and all subsequent messages will be cleared.';
+  String get replayTip =>
+      'The replayed messages and all subsequent messages will be cleared.';
 
   @override
   String get res => 'Resource';
@@ -343,7 +353,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveErrChat => 'Save chat with errors';
 
   @override
-  String get saveErrChatTip => 'Save the chat after each message sent or received even if it has error.';
+  String get saveErrChatTip =>
+      'Save the chat after each message sent or received even if it has error.';
 
   @override
   String get scrollSwitchChat => 'Scroll to switch chat';
@@ -361,7 +372,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareFrom => 'Share from';
 
   @override
-  String get skipSameTitle => 'Skip chats with titles that are the same as local chats.';
+  String get skipSameTitle =>
+      'Skip chats with titles that are the same as local chats.';
 
   @override
   String get softWrap => 'Soft wrap';

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Similar a https://api.openai.com/v1 (requiriendo el /v1 final). ¿Continuar usando esta URL?';
+  String get apiUrlV1Tip =>
+      'Similar a https://api.openai.com/v1 (requiriendo el /v1 final). ¿Continuar usando esta URL?';
 
   @override
   String get assistant => 'Asistente';
@@ -31,7 +34,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoScrollBottom => 'Desplazamiento automático hacia abajo';
 
   @override
-  String get backupTip => '¡Por favor, asegúrese de que su archivo de respaldo sea privado y seguro!';
+  String get backupTip =>
+      '¡Por favor, asegúrese de que su archivo de respaldo sea privado y seguro!';
 
   @override
   String get balance => 'Saldo';
@@ -40,7 +44,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get calcTokenLen => 'Calcular longitud de tokens';
 
   @override
-  String get changeModelTip => 'Diferentes claves pueden acceder a diferentes listas de modelos. Si no entiendes el mecanismo y ocurren errores, se recomienda reconfigurar el modelo.';
+  String get changeModelTip =>
+      'Diferentes claves pueden acceder a diferentes listas de modelos. Si no entiendes el mecanismo y ocurren errores, se recomienda reconfigurar el modelo.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +118,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get emptyTrash => 'Vaciar la papelera de reciclaje';
 
   @override
-  String get emptyTrashTip => '==0, eliminar en el próximo inicio. <0 no eliminar automáticamente.';
+  String get emptyTrashTip =>
+      '==0, eliminar en el próximo inicio. <0 no eliminar automáticamente.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get headTailMode => 'Modo cabeza-cola';
 
   @override
-  String get headTailModeTip => 'Solo envía `prompt + primer mensaje del usuario + entrada actual` como contexto.\n\nEsto es especialmente útil para traducir conversaciones (ahorra tokens).';
+  String get headTailModeTip =>
+      'Solo envía `prompt + primer mensaje del usuario + entrada actual` como contexto.\n\nEsto es especialmente útil para traducir conversaciones (ahorra tokens).';
 
   @override
   String get help => 'Ayuda';
@@ -167,7 +174,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get hour => 'hora';
 
   @override
-  String get httpToolTip => 'Realizar una solicitud HTTP, por ejemplo: buscar contenido';
+  String get httpToolTip =>
+      'Realizar una solicitud HTTP, por ejemplo: buscar contenido';
 
   @override
   String get ignoreContextConstraint => 'Ignorar restricción de contexto';
@@ -223,7 +231,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get message => 'Mensaje';
 
   @override
-  String get migrationV1UrlTip => '¿Se debe agregar automáticamente \"/v1\" al final de la configuración?';
+  String get migrationV1UrlTip =>
+      '¿Se debe agregar automáticamente \"/v1\" al final de la configuración?';
 
   @override
   String get minute => 'minuto';
@@ -232,7 +241,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get model => 'Modelo';
 
   @override
-  String get modelRegExpTip => 'Si el nombre del modelo coincide, se usarán las herramientas';
+  String get modelRegExpTip =>
+      'Si el nombre del modelo coincide, se usarán las herramientas';
 
   @override
   String get more => 'Más';
@@ -244,7 +254,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get myOtherApps => 'Mis otras aplicaciones';
 
   @override
-  String get needOpenAIKey => 'Por favor, introduzca primero la clave de OpenAI';
+  String get needOpenAIKey =>
+      'Por favor, introduzca primero la clave de OpenAI';
 
   @override
   String get needRestart => 'Se necesita reiniciar para aplicar';
@@ -267,7 +278,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onSwitchChat => 'Al cambiar de conversación';
 
   @override
-  String get onlyRestoreHistory => 'Solo restaurar historial de chat (no restaurar URL de API ni clave secreta)';
+  String get onlyRestoreHistory =>
+      'Solo restaurar historial de chat (no restaurar URL de API ni clave secreta)';
 
   @override
   String get onlySyncOnLaunch => 'Sincronizar solo al iniciar';
@@ -294,7 +306,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get promptsSettingsItem => 'Indicaciones';
 
   @override
-  String get quickShareTip => 'Abre este enlace en otro dispositivo para importar rápidamente la configuración actual.';
+  String get quickShareTip =>
+      'Abre este enlace en otro dispositivo para importar rápidamente la configuración actual.';
 
   @override
   String get raw => 'Crudo';
@@ -315,7 +328,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get replay => 'Repetir';
 
   @override
-  String get replayTip => 'Los mensajes reproducidos y todos los mensajes posteriores se borrarán.';
+  String get replayTip =>
+      'Los mensajes reproducidos y todos los mensajes posteriores se borrarán.';
 
   @override
   String get res => 'Recurso';
@@ -343,7 +357,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get saveErrChat => 'Guardar chat con error';
 
   @override
-  String get saveErrChatTip => 'Guardar después de recibir/enviar cada mensaje, incluso si hay errores';
+  String get saveErrChatTip =>
+      'Guardar después de recibir/enviar cada mensaje, incluso si hay errores';
 
   @override
   String get scrollSwitchChat => 'Desplazar para cambiar de chat';
@@ -361,7 +376,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareFrom => 'Compartido desde';
 
   @override
-  String get skipSameTitle => 'Omitir chats con el mismo título que los chats locales';
+  String get skipSameTitle =>
+      'Omitir chats con el mismo título que los chats locales';
 
   @override
   String get softWrap => 'Ajuste de línea';

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Similaire à https://api.openai.com/v1 (nécessitant le /v1 final). Continuer à utiliser cette URL ?';
+  String get apiUrlV1Tip =>
+      'Similaire à https://api.openai.com/v1 (nécessitant le /v1 final). Continuer à utiliser cette URL ?';
 
   @override
   String get assistant => 'Assistant';
@@ -31,7 +34,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoScrollBottom => 'Défilement automatique vers le bas';
 
   @override
-  String get backupTip => 'Assurez-vous que votre fichier de sauvegarde est privé et sécurisé !';
+  String get backupTip =>
+      'Assurez-vous que votre fichier de sauvegarde est privé et sécurisé !';
 
   @override
   String get balance => 'Solde';
@@ -40,7 +44,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get calcTokenLen => 'Calculer la longueur des tokens';
 
   @override
-  String get changeModelTip => 'Différentes clés peuvent accéder à différentes listes de modèles. Si vous ne comprenez pas le mécanisme et que des erreurs surviennent, il est recommandé de reconfigurer le modèle.';
+  String get changeModelTip =>
+      'Différentes clés peuvent accéder à différentes listes de modèles. Si vous ne comprenez pas le mécanisme et que des erreurs surviennent, il est recommandé de reconfigurer le modèle.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +118,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get emptyTrash => 'Vider la corbeille';
 
   @override
-  String get emptyTrashTip => '==0, supprimer au prochain démarrage. <0 ne pas supprimer automatiquement.';
+  String get emptyTrashTip =>
+      '==0, supprimer au prochain démarrage. <0 ne pas supprimer automatiquement.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get headTailMode => 'Mode tête-queue';
 
   @override
-  String get headTailModeTip => 'Envoie seulement `prompt + premier message utilisateur + entrée actuelle` comme contexte.\n\nCeci est particulièrement utile pour traduire des conversations (économise des tokens).';
+  String get headTailModeTip =>
+      'Envoie seulement `prompt + premier message utilisateur + entrée actuelle` comme contexte.\n\nCeci est particulièrement utile pour traduire des conversations (économise des tokens).';
 
   @override
   String get help => 'Aide';
@@ -167,7 +174,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get hour => 'heure';
 
   @override
-  String get httpToolTip => 'Effectuer une requête HTTP, par exemple : rechercher du contenu';
+  String get httpToolTip =>
+      'Effectuer une requête HTTP, par exemple : rechercher du contenu';
 
   @override
   String get ignoreContextConstraint => 'Ignorer la contrainte de contexte';
@@ -223,7 +231,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get message => 'Message';
 
   @override
-  String get migrationV1UrlTip => 'Faut-il ajouter automatiquement \"/v1\" à la fin de la configuration ?';
+  String get migrationV1UrlTip =>
+      'Faut-il ajouter automatiquement \"/v1\" à la fin de la configuration ?';
 
   @override
   String get minute => 'minute';
@@ -232,7 +241,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get model => 'Modèle';
 
   @override
-  String get modelRegExpTip => 'Si le nom du modèle correspond, les outils seront utilisés';
+  String get modelRegExpTip =>
+      'Si le nom du modèle correspond, les outils seront utilisés';
 
   @override
   String get more => 'Plus';
@@ -267,7 +277,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onSwitchChat => 'Lors du changement de conversation';
 
   @override
-  String get onlyRestoreHistory => 'Restaurer uniquement l\'historique des chats (ne pas restaurer l\'URL de l\'API et la clé secrète)';
+  String get onlyRestoreHistory =>
+      'Restaurer uniquement l\'historique des chats (ne pas restaurer l\'URL de l\'API et la clé secrète)';
 
   @override
   String get onlySyncOnLaunch => 'Synchroniser uniquement au lancement';
@@ -294,7 +305,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get promptsSettingsItem => 'Invites';
 
   @override
-  String get quickShareTip => 'Ouvrez ce lien sur un autre appareil pour importer rapidement la configuration actuelle.';
+  String get quickShareTip =>
+      'Ouvrez ce lien sur un autre appareil pour importer rapidement la configuration actuelle.';
 
   @override
   String get raw => 'Brut';
@@ -315,7 +327,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get replay => 'Rejouer';
 
   @override
-  String get replayTip => 'Les messages rejoués et tous les messages suivants seront effacés.';
+  String get replayTip =>
+      'Les messages rejoués et tous les messages suivants seront effacés.';
 
   @override
   String get res => 'Ressource';
@@ -343,7 +356,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get saveErrChat => 'Enregistrer le chat avec erreur';
 
   @override
-  String get saveErrChatTip => 'Enregistrer après réception/envoi de chaque message, même s\'il y a des erreurs';
+  String get saveErrChatTip =>
+      'Enregistrer après réception/envoi de chaque message, même s\'il y a des erreurs';
 
   @override
   String get scrollSwitchChat => 'Faire défiler pour changer de chat';
@@ -361,7 +375,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareFrom => 'Partagé depuis';
 
   @override
-  String get skipSameTitle => 'Ignorer les chats avec le même titre que les chats locaux';
+  String get skipSameTitle =>
+      'Ignorer les chats avec le même titre que les chats locaux';
 
   @override
   String get softWrap => 'Retour à la ligne automatique';

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Mirip dengan https://api.openai.com/v1 (memerlukan /v1 di akhir). Lanjutkan menggunakan URL ini?';
+  String get apiUrlV1Tip =>
+      'Mirip dengan https://api.openai.com/v1 (memerlukan /v1 di akhir). Lanjutkan menggunakan URL ini?';
 
   @override
   String get assistant => 'Asisten';
@@ -31,7 +34,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get autoScrollBottom => 'Gulir ke bawah secara otomatis';
 
   @override
-  String get backupTip => 'Pastikan file cadangan Anda bersifat pribadi dan aman!';
+  String get backupTip =>
+      'Pastikan file cadangan Anda bersifat pribadi dan aman!';
 
   @override
   String get balance => 'Saldo';
@@ -40,7 +44,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get calcTokenLen => 'Hitung panjang Token';
 
   @override
-  String get changeModelTip => 'Kunci yang berbeda mungkin dapat mengakses daftar model yang berbeda. Jika Anda tidak memahami mekanismenya dan terjadi kesalahan, disarankan untuk mengatur ulang model.';
+  String get changeModelTip =>
+      'Kunci yang berbeda mungkin dapat mengakses daftar model yang berbeda. Jika Anda tidak memahami mekanismenya dan terjadi kesalahan, disarankan untuk mengatur ulang model.';
 
   @override
   String get chat => 'Obrolan';
@@ -113,7 +118,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get emptyTrash => 'Kosongkan tempat sampah';
 
   @override
-  String get emptyTrashTip => '==0, hapus saat mulai berikutnya. <0 jangan hapus secara otomatis.';
+  String get emptyTrashTip =>
+      '==0, hapus saat mulai berikutnya. <0 jangan hapus secara otomatis.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get headTailMode => 'Mode kepala-ekor';
 
   @override
-  String get headTailModeTip => 'Hanya mengirim `prompt + pesan pengguna pertama + input saat ini` sebagai konteks.\n\nIni sangat berguna saat menerjemahkan percakapan (menghemat token).';
+  String get headTailModeTip =>
+      'Hanya mengirim `prompt + pesan pengguna pertama + input saat ini` sebagai konteks.\n\nIni sangat berguna saat menerjemahkan percakapan (menghemat token).';
 
   @override
   String get help => 'Bantuan';
@@ -223,7 +230,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get message => 'Pesan';
 
   @override
-  String get migrationV1UrlTip => 'Haruskah \"/v1\" ditambahkan secara otomatis di akhir konfigurasi?';
+  String get migrationV1UrlTip =>
+      'Haruskah \"/v1\" ditambahkan secara otomatis di akhir konfigurasi?';
 
   @override
   String get minute => 'menit';
@@ -267,7 +275,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get onSwitchChat => 'Saat beralih percakapan';
 
   @override
-  String get onlyRestoreHistory => 'Hanya pulihkan riwayat obrolan (tidak memulihkan URL API dan Kunci Rahasia)';
+  String get onlyRestoreHistory =>
+      'Hanya pulihkan riwayat obrolan (tidak memulihkan URL API dan Kunci Rahasia)';
 
   @override
   String get onlySyncOnLaunch => 'Hanya sinkronkan saat peluncuran';
@@ -294,7 +303,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get promptsSettingsItem => 'Prompt';
 
   @override
-  String get quickShareTip => 'Buka tautan ini di perangkat lain untuk dengan cepat mengimpor konfigurasi saat ini.';
+  String get quickShareTip =>
+      'Buka tautan ini di perangkat lain untuk dengan cepat mengimpor konfigurasi saat ini.';
 
   @override
   String get raw => 'Mentah';
@@ -315,7 +325,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get replay => 'Putar ulang';
 
   @override
-  String get replayTip => 'Pesan yang diputar ulang dan semua pesan selanjutnya akan dihapus.';
+  String get replayTip =>
+      'Pesan yang diputar ulang dan semua pesan selanjutnya akan dihapus.';
 
   @override
   String get res => 'Sumber daya';
@@ -343,7 +354,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get saveErrChat => 'Simpan obrolan error';
 
   @override
-  String get saveErrChatTip => 'Simpan setelah menerima/mengirim setiap pesan, bahkan jika ada kesalahan';
+  String get saveErrChatTip =>
+      'Simpan setelah menerima/mengirim setiap pesan, bahkan jika ada kesalahan';
 
   @override
   String get scrollSwitchChat => 'Gulir untuk beralih obrolan';
@@ -361,7 +373,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareFrom => 'Dibagikan dari';
 
   @override
-  String get skipSameTitle => 'Lewati obrolan dengan judul yang sama dengan obrolan lokal';
+  String get skipSameTitle =>
+      'Lewati obrolan dengan judul yang sama dengan obrolan lokal';
 
   @override
   String get softWrap => 'Pembungkus lunak';

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'https://api.openai.com/v1に似ています（最後の /v1 が必要）。このURLを引き続き使用しますか？';
+  String get apiUrlV1Tip =>
+      'https://api.openai.com/v1に似ています（最後の /v1 が必要）。このURLを引き続き使用しますか？';
 
   @override
   String get assistant => 'アシスタント';
@@ -40,7 +43,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get calcTokenLen => 'トークン長を計算';
 
   @override
-  String get changeModelTip => '異なるキーで利用可能なモデルリストが異なる場合があります。メカニズムがわからない場合やエラーが発生する場合は、モデルを再設定することをお勧めします。';
+  String get changeModelTip =>
+      '異なるキーで利用可能なモデルリストが異なる場合があります。メカニズムがわからない場合やエラーが発生する場合は、モデルを再設定することをお勧めします。';
 
   @override
   String get chat => 'チャット';
@@ -147,7 +151,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get headTailMode => 'ヘッドテールモード';
 
   @override
-  String get headTailModeTip => '`プロンプト+最初のユーザーメッセージ+現在の入力`のみをコンテキストとして送信します。\n\nこれは会話の翻訳に特に有用です（トークンを節約できます）。';
+  String get headTailModeTip =>
+      '`プロンプト+最初のユーザーメッセージ+現在の入力`のみをコンテキストとして送信します。\n\nこれは会話の翻訳に特に有用です（トークンを節約できます）。';
 
   @override
   String get help => 'ヘルプ';

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Vergelijkbaar met https://api.openai.com/v1 (met de laatste /v1 vereist). Doorgaan met het gebruik van deze URL?';
+  String get apiUrlV1Tip =>
+      'Vergelijkbaar met https://api.openai.com/v1 (met de laatste /v1 vereist). Doorgaan met het gebruik van deze URL?';
 
   @override
   String get assistant => 'Assistent';
@@ -31,7 +34,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoScrollBottom => 'Automatisch naar beneden scrollen';
 
   @override
-  String get backupTip => 'Zorg ervoor dat uw back-upbestand privé en veilig is!';
+  String get backupTip =>
+      'Zorg ervoor dat uw back-upbestand privé en veilig is!';
 
   @override
   String get balance => 'Saldo';
@@ -40,7 +44,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get calcTokenLen => 'Tokenlengte berekenen';
 
   @override
-  String get changeModelTip => 'Verschillende sleutels kunnen toegang hebben tot verschillende modellijsten. Als u het mechanisme niet begrijpt en er fouten optreden, is het raadzaam om het model opnieuw in te stellen.';
+  String get changeModelTip =>
+      'Verschillende sleutels kunnen toegang hebben tot verschillende modellijsten. Als u het mechanisme niet begrijpt en er fouten optreden, is het raadzaam om het model opnieuw in te stellen.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +118,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get emptyTrash => 'Prullenbak leegmaken';
 
   @override
-  String get emptyTrashTip => '==0, bij de volgende start verwijderen. <0 niet automatisch verwijderen.';
+  String get emptyTrashTip =>
+      '==0, bij de volgende start verwijderen. <0 niet automatisch verwijderen.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get headTailMode => 'Kop-staart modus';
 
   @override
-  String get headTailModeTip => 'Stuurt alleen `prompt + eerste gebruikersbericht + huidige invoer` als context.\n\nDit is vooral handig voor het vertalen van gesprekken (bespaart tokens).';
+  String get headTailModeTip =>
+      'Stuurt alleen `prompt + eerste gebruikersbericht + huidige invoer` als context.\n\nDit is vooral handig voor het vertalen van gesprekken (bespaart tokens).';
 
   @override
   String get help => 'Help';
@@ -167,7 +174,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get hour => 'uur';
 
   @override
-  String get httpToolTip => 'HTTP-verzoek uitvoeren, bijvoorbeeld: inhoud zoeken';
+  String get httpToolTip =>
+      'HTTP-verzoek uitvoeren, bijvoorbeeld: inhoud zoeken';
 
   @override
   String get ignoreContextConstraint => 'Contextbeperking negeren';
@@ -223,7 +231,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get message => 'Bericht';
 
   @override
-  String get migrationV1UrlTip => 'Moet \"/v1\" automatisch worden toegevoegd aan het einde van de configuratie?';
+  String get migrationV1UrlTip =>
+      'Moet \"/v1\" automatisch worden toegevoegd aan het einde van de configuratie?';
 
   @override
   String get minute => 'minuut';
@@ -232,7 +241,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get model => 'Model';
 
   @override
-  String get modelRegExpTip => 'Als de modelnaam overeenkomt, worden tools gebruikt';
+  String get modelRegExpTip =>
+      'Als de modelnaam overeenkomt, worden tools gebruikt';
 
   @override
   String get more => 'Meer';
@@ -267,7 +277,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onSwitchChat => 'Bij het wisselen van gesprekken';
 
   @override
-  String get onlyRestoreHistory => 'Alleen chatgeschiedenis herstellen (API-URL en geheime sleutel niet herstellen)';
+  String get onlyRestoreHistory =>
+      'Alleen chatgeschiedenis herstellen (API-URL en geheime sleutel niet herstellen)';
 
   @override
   String get onlySyncOnLaunch => 'Alleen synchroniseren bij opstarten';
@@ -294,7 +305,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip => 'Open deze link op een ander apparaat om de huidige configuratie snel te importeren.';
+  String get quickShareTip =>
+      'Open deze link op een ander apparaat om de huidige configuratie snel te importeren.';
 
   @override
   String get raw => 'Onbewerkt';
@@ -315,7 +327,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get replay => 'Herhalen';
 
   @override
-  String get replayTip => 'De herhaalde berichten en alle volgende berichten worden gewist.';
+  String get replayTip =>
+      'De herhaalde berichten en alle volgende berichten worden gewist.';
 
   @override
   String get res => 'Bron';
@@ -343,7 +356,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get saveErrChat => 'Foutieve chat opslaan';
 
   @override
-  String get saveErrChatTip => 'Opslaan na ontvangen/verzenden van elk bericht, zelfs als er fouten zijn';
+  String get saveErrChatTip =>
+      'Opslaan na ontvangen/verzenden van elk bericht, zelfs als er fouten zijn';
 
   @override
   String get scrollSwitchChat => 'Scrollen om van chat te wisselen';
@@ -361,7 +375,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareFrom => 'Gedeeld van';
 
   @override
-  String get skipSameTitle => 'Chats met dezelfde titel als lokale chats overslaan';
+  String get skipSameTitle =>
+      'Chats met dezelfde titel als lokale chats overslaan';
 
   @override
   String get softWrap => 'Zachte terugloop';

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Semelhante a https://api.openai.com/v1 (requerendo o /v1 final). Continuar usando esta URL?';
+  String get apiUrlV1Tip =>
+      'Semelhante a https://api.openai.com/v1 (requerendo o /v1 final). Continuar usando esta URL?';
 
   @override
   String get assistant => 'Assistente';
@@ -31,7 +34,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoScrollBottom => 'Rolar automaticamente para baixo';
 
   @override
-  String get backupTip => 'Por favor, certifique-se de que seu arquivo de backup é privado e seguro!';
+  String get backupTip =>
+      'Por favor, certifique-se de que seu arquivo de backup é privado e seguro!';
 
   @override
   String get balance => 'Saldo';
@@ -40,7 +44,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get calcTokenLen => 'Calcular comprimento dos tokens';
 
   @override
-  String get changeModelTip => 'Diferentes chaves podem acessar diferentes listas de modelos. Se você não entende o mecanismo e ocorrem erros, é recomendável reconfigurar o modelo.';
+  String get changeModelTip =>
+      'Diferentes chaves podem acessar diferentes listas de modelos. Se você não entende o mecanismo e ocorrem erros, é recomendável reconfigurar o modelo.';
 
   @override
   String get chat => 'Chat';
@@ -113,7 +118,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get emptyTrash => 'Esvaziar a lixeira';
 
   @override
-  String get emptyTrashTip => '==0, excluir na próxima inicialização. <0 não excluir automaticamente.';
+  String get emptyTrashTip =>
+      '==0, excluir na próxima inicialização. <0 não excluir automaticamente.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get headTailMode => 'Modo cabeça-cauda';
 
   @override
-  String get headTailModeTip => 'Envia apenas `prompt + primeira mensagem do usuário + entrada atual` como contexto.\n\nIsso é especialmente útil para traduzir conversas (economiza tokens).';
+  String get headTailModeTip =>
+      'Envia apenas `prompt + primeira mensagem do usuário + entrada atual` como contexto.\n\nIsso é especialmente útil para traduzir conversas (economiza tokens).';
 
   @override
   String get help => 'Ajuda';
@@ -167,7 +174,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get hour => 'hora';
 
   @override
-  String get httpToolTip => 'Realizar uma solicitação HTTP, por exemplo: pesquisar conteúdo';
+  String get httpToolTip =>
+      'Realizar uma solicitação HTTP, por exemplo: pesquisar conteúdo';
 
   @override
   String get ignoreContextConstraint => 'Ignorar restrição de contexto';
@@ -223,7 +231,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get message => 'Mensagem';
 
   @override
-  String get migrationV1UrlTip => 'Deve-se adicionar automaticamente \"/v1\" ao final da configuração?';
+  String get migrationV1UrlTip =>
+      'Deve-se adicionar automaticamente \"/v1\" ao final da configuração?';
 
   @override
   String get minute => 'minuto';
@@ -232,7 +241,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get model => 'Modelo';
 
   @override
-  String get modelRegExpTip => 'Se o nome do modelo corresponder, as ferramentas serão usadas';
+  String get modelRegExpTip =>
+      'Se o nome do modelo corresponder, as ferramentas serão usadas';
 
   @override
   String get more => 'Mais';
@@ -267,7 +277,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onSwitchChat => 'Ao alternar conversas';
 
   @override
-  String get onlyRestoreHistory => 'Restaurar apenas o histórico de chat (não restaurar URL da API e chave secreta)';
+  String get onlyRestoreHistory =>
+      'Restaurar apenas o histórico de chat (não restaurar URL da API e chave secreta)';
 
   @override
   String get onlySyncOnLaunch => 'Sincronizar apenas na inicialização';
@@ -294,7 +305,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip => 'Abra este link em outro dispositivo para importar rapidamente a configuração atual.';
+  String get quickShareTip =>
+      'Abra este link em outro dispositivo para importar rapidamente a configuração atual.';
 
   @override
   String get raw => 'Bruto';
@@ -315,7 +327,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get replay => 'Repetir';
 
   @override
-  String get replayTip => 'As mensagens reproduzidas e todas as mensagens subsequentes serão apagadas.';
+  String get replayTip =>
+      'As mensagens reproduzidas e todas as mensagens subsequentes serão apagadas.';
 
   @override
   String get res => 'Recurso';
@@ -343,7 +356,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get saveErrChat => 'Salvar chat com erro';
 
   @override
-  String get saveErrChatTip => 'Salvar após receber/enviar cada mensagem, mesmo se houver erros';
+  String get saveErrChatTip =>
+      'Salvar após receber/enviar cada mensagem, mesmo se houver erros';
 
   @override
   String get scrollSwitchChat => 'Rolar para alternar chat';
@@ -361,7 +375,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareFrom => 'Compartilhado de';
 
   @override
-  String get skipSameTitle => 'Pular chats com o mesmo título que os chats locais';
+  String get skipSameTitle =>
+      'Pular chats com o mesmo título que os chats locais';
 
   @override
   String get softWrap => 'Quebra de linha suave';

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Похоже на https://api.openai.com/v1 (требуется конечный /v1). Продолжить использование этого URL?';
+  String get apiUrlV1Tip =>
+      'Похоже на https://api.openai.com/v1 (требуется конечный /v1). Продолжить использование этого URL?';
 
   @override
   String get assistant => 'Ассистент';
@@ -31,7 +34,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoScrollBottom => 'Автоматическая прокрутка вниз';
 
   @override
-  String get backupTip => 'Пожалуйста, убедитесь, что ваш файл резервной копии является приватным и безопасным!';
+  String get backupTip =>
+      'Пожалуйста, убедитесь, что ваш файл резервной копии является приватным и безопасным!';
 
   @override
   String get balance => 'Баланс';
@@ -40,7 +44,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get calcTokenLen => 'Рассчитать длину токенов';
 
   @override
-  String get changeModelTip => 'Разные ключи могут иметь доступ к разным спискам моделей. Если вы не понимаете механизм и возникают ошибки, рекомендуется переустановить модель.';
+  String get changeModelTip =>
+      'Разные ключи могут иметь доступ к разным спискам моделей. Если вы не понимаете механизм и возникают ошибки, рекомендуется переустановить модель.';
 
   @override
   String get chat => 'Чат';
@@ -113,7 +118,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get emptyTrash => 'Очистить корзину';
 
   @override
-  String get emptyTrashTip => '==0, удалить при следующем запуске. <0 не удалять автоматически.';
+  String get emptyTrashTip =>
+      '==0, удалить при следующем запуске. <0 не удалять автоматически.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get headTailMode => 'Режим начало-конец';
 
   @override
-  String get headTailModeTip => 'Отправляет только `подсказку + первое сообщение пользователя + текущий ввод` в качестве контекста.\n\nЭто особенно полезно для перевода разговоров (экономит токены).';
+  String get headTailModeTip =>
+      'Отправляет только `подсказку + первое сообщение пользователя + текущий ввод` в качестве контекста.\n\nЭто особенно полезно для перевода разговоров (экономит токены).';
 
   @override
   String get help => 'Помощь';
@@ -223,7 +230,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get message => 'Сообщение';
 
   @override
-  String get migrationV1UrlTip => 'Следует ли автоматически добавлять \"/v1\" в конец конфигурации?';
+  String get migrationV1UrlTip =>
+      'Следует ли автоматически добавлять \"/v1\" в конец конфигурации?';
 
   @override
   String get minute => 'минута';
@@ -232,7 +240,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get model => 'Модель';
 
   @override
-  String get modelRegExpTip => 'Если имя модели совпадает, будут использованы инструменты';
+  String get modelRegExpTip =>
+      'Если имя модели совпадает, будут использованы инструменты';
 
   @override
   String get more => 'Больше';
@@ -267,7 +276,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onSwitchChat => 'При переключении разговора';
 
   @override
-  String get onlyRestoreHistory => 'Восстановить только историю чатов (не восстанавливать URL API и секретный ключ)';
+  String get onlyRestoreHistory =>
+      'Восстановить только историю чатов (не восстанавливать URL API и секретный ключ)';
 
   @override
   String get onlySyncOnLaunch => 'Синхронизировать только при запуске';
@@ -294,7 +304,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get promptsSettingsItem => 'Подсказки';
 
   @override
-  String get quickShareTip => 'Откройте эту ссылку на другом устройстве, чтобы быстро импортировать текущую конфигурацию.';
+  String get quickShareTip =>
+      'Откройте эту ссылку на другом устройстве, чтобы быстро импортировать текущую конфигурацию.';
 
   @override
   String get raw => 'Необработанный';
@@ -315,7 +326,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get replay => 'Повтор';
 
   @override
-  String get replayTip => 'Воспроизведенные сообщения и все последующие сообщения будут удалены.';
+  String get replayTip =>
+      'Воспроизведенные сообщения и все последующие сообщения будут удалены.';
 
   @override
   String get res => 'Ресурс';
@@ -343,7 +355,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get saveErrChat => 'Сохранить чат с ошибкой';
 
   @override
-  String get saveErrChatTip => 'Сохранять после получения/отправки каждого сообщения, даже если есть ошибки';
+  String get saveErrChatTip =>
+      'Сохранять после получения/отправки каждого сообщения, даже если есть ошибки';
 
   @override
   String get scrollSwitchChat => 'Прокрутка для переключения чата';
@@ -361,7 +374,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get shareFrom => 'Поделился';
 
   @override
-  String get skipSameTitle => 'Пропустить чаты с тем же заголовком, что и у локальных чатов';
+  String get skipSameTitle =>
+      'Пропустить чаты с тем же заголовком, что и у локальных чатов';
 
   @override
   String get softWrap => 'Мягкий перенос';

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'https://api.openai.com/v1 gibi (sondaki /v1 gerekli). Bu URL\'yi kullanmaya devam edilsin mi?';
+  String get apiUrlV1Tip =>
+      'https://api.openai.com/v1 gibi (sondaki /v1 gerekli). Bu URL\'yi kullanmaya devam edilsin mi?';
 
   @override
   String get assistant => 'Asistan';
@@ -31,7 +34,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get autoScrollBottom => 'Otomatik aşağı kaydır';
 
   @override
-  String get backupTip => 'Lütfen yedekleme dosyanızın özel ve güvenli olduğundan emin olun!';
+  String get backupTip =>
+      'Lütfen yedekleme dosyanızın özel ve güvenli olduğundan emin olun!';
 
   @override
   String get balance => 'Bakiye';
@@ -40,7 +44,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get calcTokenLen => 'Token uzunluğunu hesapla';
 
   @override
-  String get changeModelTip => 'Farklı anahtarlar farklı model listelerine erişebilir. Mekanizmayı anlamıyorsanız ve hatalar oluşuyorsa, modeli yeniden ayarlamanız önerilir.';
+  String get changeModelTip =>
+      'Farklı anahtarlar farklı model listelerine erişebilir. Mekanizmayı anlamıyorsanız ve hatalar oluşuyorsa, modeli yeniden ayarlamanız önerilir.';
 
   @override
   String get chat => 'Sohbet';
@@ -113,7 +118,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get emptyTrash => 'Geri dönüşüm kutusunu boşalt';
 
   @override
-  String get emptyTrashTip => '==0, bir sonraki başlangıçta sil. <0 otomatik olarak silme.';
+  String get emptyTrashTip =>
+      '==0, bir sonraki başlangıçta sil. <0 otomatik olarak silme.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get headTailMode => 'Baş-Kuyruk modu';
 
   @override
-  String get headTailModeTip => 'Sadece `prompt + ilk kullanıcı mesajı + mevcut giriş` bağlam olarak gönderilir.\n\nBu özellikle konuşmaları çevirmek için kullanışlıdır (token tasarrufu sağlar).';
+  String get headTailModeTip =>
+      'Sadece `prompt + ilk kullanıcı mesajı + mevcut giriş` bağlam olarak gönderilir.\n\nBu özellikle konuşmaları çevirmek için kullanışlıdır (token tasarrufu sağlar).';
 
   @override
   String get help => 'Yardım';
@@ -223,7 +230,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get message => 'Mesaj';
 
   @override
-  String get migrationV1UrlTip => 'Yapılandırmanın sonuna otomatik olarak \"/v1\" eklensin mi?';
+  String get migrationV1UrlTip =>
+      'Yapılandırmanın sonuna otomatik olarak \"/v1\" eklensin mi?';
 
   @override
   String get minute => 'dakika';
@@ -267,7 +275,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get onSwitchChat => 'Konuşmalar arasında geçiş yaparken';
 
   @override
-  String get onlyRestoreHistory => 'Sadece sohbet geçmişini geri yükle (API URL\'sini ve gizli anahtarı geri yükleme)';
+  String get onlyRestoreHistory =>
+      'Sadece sohbet geçmişini geri yükle (API URL\'sini ve gizli anahtarı geri yükleme)';
 
   @override
   String get onlySyncOnLaunch => 'Sadece başlatırken senkronize et';
@@ -294,7 +303,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get promptsSettingsItem => 'Komutlar';
 
   @override
-  String get quickShareTip => 'Mevcut yapılandırmayı hızlıca içe aktarmak için bu bağlantıyı başka bir cihazda açın.';
+  String get quickShareTip =>
+      'Mevcut yapılandırmayı hızlıca içe aktarmak için bu bağlantıyı başka bir cihazda açın.';
 
   @override
   String get raw => 'Ham';
@@ -315,7 +325,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get replay => 'Tekrar oynat';
 
   @override
-  String get replayTip => 'Tekrar oynatılan mesajlar ve sonraki tüm mesajlar temizlenecek.';
+  String get replayTip =>
+      'Tekrar oynatılan mesajlar ve sonraki tüm mesajlar temizlenecek.';
 
   @override
   String get res => 'Kaynak';
@@ -343,7 +354,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get saveErrChat => 'Hatalı sohbeti kaydet';
 
   @override
-  String get saveErrChatTip => 'Her mesajı aldıktan/gönderdikten sonra kaydet, hata olsa bile';
+  String get saveErrChatTip =>
+      'Her mesajı aldıktan/gönderdikten sonra kaydet, hata olsa bile';
 
   @override
   String get scrollSwitchChat => 'Sohbeti değiştirmek için kaydır';
@@ -361,7 +373,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareFrom => 'Paylaşan';
 
   @override
-  String get skipSameTitle => 'Yerel sohbetlerle aynı başlığa sahip sohbetleri atla';
+  String get skipSameTitle =>
+      'Yerel sohbetlerle aynı başlığa sahip sohbetleri atla';
 
   @override
   String get softWrap => 'Yumuşak kaydırma';

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsUk extends AppLocalizations {
   AppLocalizationsUk([String locale = 'uk']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => 'Схоже на https://api.openai.com/v1 (потрібен кінцевий /v1). Продовжити використання цього URL?';
+  String get apiUrlV1Tip =>
+      'Схоже на https://api.openai.com/v1 (потрібен кінцевий /v1). Продовжити використання цього URL?';
 
   @override
   String get assistant => 'Асистент';
@@ -31,7 +34,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get autoScrollBottom => 'Автоматично прокручувати до низу';
 
   @override
-  String get backupTip => 'Будь ласка, зберігайте резервну копію файлу в безпеці та приватності!';
+  String get backupTip =>
+      'Будь ласка, зберігайте резервну копію файлу в безпеці та приватності!';
 
   @override
   String get balance => 'Баланс';
@@ -40,7 +44,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get calcTokenLen => 'Обчислити довжину токенів';
 
   @override
-  String get changeModelTip => 'Різні ключі можуть мати доступ до різних списків моделей. Якщо ви не розумієте механізму і виникають помилки, рекомендується переналаштувати модель.';
+  String get changeModelTip =>
+      'Різні ключі можуть мати доступ до різних списків моделей. Якщо ви не розумієте механізму і виникають помилки, рекомендується переналаштувати модель.';
 
   @override
   String get chat => 'Чат';
@@ -113,7 +118,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get emptyTrash => 'Очистити кошик';
 
   @override
-  String get emptyTrashTip => '==0, видалити під час наступного запуску. <0 не видаляти автоматично.';
+  String get emptyTrashTip =>
+      '==0, видалити під час наступного запуску. <0 не видаляти автоматично.';
 
   @override
   String fileNotFound(Object file) {
@@ -147,7 +153,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get headTailMode => 'Режим голова-хвіст';
 
   @override
-  String get headTailModeTip => 'Надсилає лише підказку + перше повідомлення користувача + поточне введення як контекст.\n\nЦе особливо корисно при перекладі діалогів (може заощадити токени).';
+  String get headTailModeTip =>
+      'Надсилає лише підказку + перше повідомлення користувача + поточне введення як контекст.\n\nЦе особливо корисно при перекладі діалогів (може заощадити токени).';
 
   @override
   String get help => 'Допомога';
@@ -223,7 +230,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get message => 'Повідомлення';
 
   @override
-  String get migrationV1UrlTip => 'Автоматично додати \"/v1\" у кінці конфігурації?';
+  String get migrationV1UrlTip =>
+      'Автоматично додати \"/v1\" у кінці конфігурації?';
 
   @override
   String get minute => 'Хвилина';
@@ -232,7 +240,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get model => 'Модель';
 
   @override
-  String get modelRegExpTip => 'Якщо назва моделі відповідає, використовувати інструменти';
+  String get modelRegExpTip =>
+      'Якщо назва моделі відповідає, використовувати інструменти';
 
   @override
   String get more => 'Більше';
@@ -267,7 +276,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get onSwitchChat => 'При перемиканні чату';
 
   @override
-  String get onlyRestoreHistory => 'Відновити лише історію чатів (без відновлення API Url та Secret Key)';
+  String get onlyRestoreHistory =>
+      'Відновити лише історію чатів (без відновлення API Url та Secret Key)';
 
   @override
   String get onlySyncOnLaunch => 'Синхронізувати лише при запуску';
@@ -294,7 +304,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get promptsSettingsItem => 'Підказки';
 
   @override
-  String get quickShareTip => 'Відкрийте це посилання на іншому пристрої, щоб швидко імпортувати поточну конфігурацію.';
+  String get quickShareTip =>
+      'Відкрийте це посилання на іншому пристрої, щоб швидко імпортувати поточну конфігурацію.';
 
   @override
   String get raw => 'Сирий';
@@ -343,10 +354,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get saveErrChat => 'Зберегти помилку чату';
 
   @override
-  String get saveErrChatTip => 'Зберігати після отримання/відправлення кожного повідомлення, навіть якщо є помилки';
+  String get saveErrChatTip =>
+      'Зберігати після отримання/відправлення кожного повідомлення, навіть якщо є помилки';
 
   @override
-  String get scrollSwitchChat => 'Прокручування вгору-вниз для перемикання чатів';
+  String get scrollSwitchChat =>
+      'Прокручування вгору-вниз для перемикання чатів';
 
   @override
   String get search => 'Пошук';
@@ -361,7 +374,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shareFrom => 'Поділитися з';
 
   @override
-  String get skipSameTitle => 'Пропустити чати з такими ж заголовками, як у локальних';
+  String get skipSameTitle =>
+      'Пропустити чати з такими ж заголовками, як у локальних';
 
   @override
   String get softWrap => 'М\'який перенос';

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -1,3 +1,5 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'l10n.dart';
 
 // ignore_for_file: type=lint
@@ -7,7 +9,8 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
-  String get apiUrlV1Tip => '类似 `https://api.openai.com/v1`（需要最后的 `/v1`）。继续使用该 URL 吗？';
+  String get apiUrlV1Tip =>
+      '类似 `https://api.openai.com/v1`（需要最后的 `/v1`）。继续使用该 URL 吗？';
 
   @override
   String get assistant => '助手';
@@ -147,7 +150,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get headTailMode => '头尾模式';
 
   @override
-  String get headTailModeTip => '仅发送 `提示词+第一条用户信息+当前输入` 作为上下文。\n\n这在用于翻译对话时特别有用（可以节省 tokens）。';
+  String get headTailModeTip =>
+      '仅发送 `提示词+第一条用户信息+当前输入` 作为上下文。\n\n这在用于翻译对话时特别有用（可以节省 tokens）。';
 
   @override
   String get help => '帮助';
@@ -445,10 +449,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
 class AppLocalizationsZhTw extends AppLocalizationsZh {
-  AppLocalizationsZhTw(): super('zh_TW');
+  AppLocalizationsZhTw() : super('zh_TW');
 
   @override
-  String get apiUrlV1Tip => '類似 https://api.openai.com/v1（需要最後的 /v1）。繼續使用該 URL 嗎？';
+  String get apiUrlV1Tip =>
+      '類似 https://api.openai.com/v1（需要最後的 /v1）。繼續使用該 URL 嗎？';
 
   @override
   String get assistant => '助手';
@@ -588,7 +593,8 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get headTailMode => '頭尾模式';
 
   @override
-  String get headTailModeTip => '僅發送 `提示詞+第一條用戶訊息+當前輸入` 作為上下文。\n\n這在用於翻譯對話時特別有用（可以節省 tokens）。';
+  String get headTailModeTip =>
+      '僅發送 `提示詞+第一條用戶訊息+當前輸入` 作為上下文。\n\n這在用於翻譯對話時特別有用（可以節省 tokens）。';
 
   @override
   String get help => '幫助';

--- a/lib/view/page/home/chat.dart
+++ b/lib/view/page/home/chat.dart
@@ -22,7 +22,6 @@ class _ChatPageState extends State<_ChatPage>
 
   Widget _buildFAB() {
     return AutoHide(
-      key: _chatFabAutoHideKey,
       scrollController: _chatScrollCtrl,
       hideController: _autoHideCtrl,
       direction: AxisDirection.right,

--- a/lib/view/page/home/ctrl.dart
+++ b/lib/view/page/home/ctrl.dart
@@ -91,7 +91,7 @@ void _onTapDelChatItem(
   if (result != true) return;
   chatItems.remove(chatItem);
   _storeChat(chatId.value);
-  _historyRNMap[chatId.value]?.notify();
+  _historyRN.notify();
   _chatRN.notify();
 }
 
@@ -182,7 +182,7 @@ void _onTapRenameChat(String chatId, BuildContext context) async {
   if (title == null || title.isEmpty) return;
   final ne = entity.copyWith(name: title)..save();
   _allHistories[chatId] = ne;
-  _historyRNMap[chatId]?.notify();
+  _historyRN.notify();
   _storeChat(chatId);
   _appbarTitleVN.value = title;
 }

--- a/lib/view/page/home/history.dart
+++ b/lib/view/page/home/history.dart
@@ -61,16 +61,13 @@ class _HistoryPageState extends State<_HistoryPage>
   Widget _buildHistoryListItem(String chatId) {
     final entity = _allHistories[chatId];
     if (entity == null) return UIs.placeholder;
-    final node = _historyRNMap.putIfAbsent(chatId, () => RNode());
+
     return ListTile(
-      title: ListenBuilder(
-        listenable: node,
-        builder: () => Text(
-          entity.name ?? l10n.untitled,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: UIs.text15,
-        ),
+      title: Text(
+        entity.name ?? l10n.untitled,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: UIs.text15,
       ),
       subtitle: ListenBuilder(
         listenable: _timeRN,

--- a/lib/view/page/home/md_copy.dart
+++ b/lib/view/page/home/md_copy.dart
@@ -12,22 +12,15 @@ final class _MarkdownCopyPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FutureWidget(
-      future: compute((e) => e.toMarkdown, args),
-      error: (e, s) => SimpleMarkdown(data: '$e\n\n$s'),
-      loading: Scaffold(
-        appBar: AppBar(
-          title: Text(l10n.raw),
-          centerTitle: false,
-          actions: const [SizedLoading.small, UIs.width7],
-        ),
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: Text(l10n.raw),
+        centerTitle: false,
       ),
-      success: (val) => Scaffold(
-        appBar: AppBar(
-          title: Text(l10n.raw),
-          centerTitle: false,
-        ),
-        body: _buildBody(val),
+      body: FutureWidget(
+        future: compute((e) => e.toMarkdown, args),
+        error: (e, s) => SimpleMarkdown(data: '$e\n\n$s'),
+        success: _buildBody,
       ),
     );
   }

--- a/lib/view/page/home/req.dart
+++ b/lib/view/page/home/req.dart
@@ -479,7 +479,7 @@ Completer<void>? _genChatTitle(
   final completer = Completer<void>();
   void onErr(Object e, StackTrace s) {
     Loggers.app.warning('Gen title: $e');
-    _historyRNMap[chatId]?.notify();
+    _historyRN.notify();
     completer.complete();
   }
 
@@ -508,7 +508,7 @@ Completer<void>? _genChatTitle(
         if (title.isNotEmpty) {
           final ne = entity.copyWith(name: title)..save();
           _allHistories[chatId] = ne;
-          _historyRNMap[chatId]?.notify();
+          _historyRN.notify();
           if (chatId == _curChatId.value) {
             _appbarTitleVN.value = title;
           }

--- a/lib/view/page/home/var.dart
+++ b/lib/view/page/home/var.dart
@@ -11,7 +11,6 @@ final _timeRN = RNode();
 
 /// Map for [ChatHistoryItem]'s [RNode]
 final _chatItemRNMap = <String, RNode>{};
-final _historyRNMap = <String, RNode>{};
 
 /// Audio / Image / File path
 final _filePicked = nvn<_FilePicked>();
@@ -56,8 +55,6 @@ final _historyLocateTollerance = _historyItemHeight / 3;
 
 const _durationShort = Durations.short4;
 const _durationMedium = Durations.medium1;
-
-final _chatFabAutoHideKey = GlobalKey<AutoHideState>();
 
 // ignore: unused_element
 KeyboardCtrlListener? _keyboardSendListener;

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,10 +42,10 @@ packages:
     dependency: "direct main"
     description:
       name: app_links
-      sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"
+      sha256: "85ed8fc1d25a76475914fff28cc994653bd900bc2c26e4b57a49e097febb54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.4.0"
   app_links_linux:
     dependency: transitive
     description:
@@ -194,10 +194,10 @@ packages:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: eff7ed630b1ac3994737c790368fe006388ad9f271d7148e432263721e45dc75
+      sha256: "1eeb9ce7c9a397e312343fd7db337d95f35c3e65ad5a62ff637c8abce5102b98"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.18+7"
+    version: "0.9.18+8"
   camera_platform_interface:
     dependency: transitive
     description:
@@ -419,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -866,10 +866,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+20"
+    version: "0.8.12+21"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1314,10 +1314,10 @@ packages:
     dependency: transitive
     description:
       name: qr_code_dart_scan
-      sha256: "62c42c0c079657a42508764311219d0f7bb41644dcc37e7619c8b9349268d258"
+      sha256: a21340c4a2ca14e2e114915940fcad166f15c1a065fed8b4fede4a4aba5bc4ff
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.10"
+    version: "0.9.11"
   recase:
     dependency: transitive
     description:
@@ -1402,10 +1402,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: ea86be7b7114f9e94fddfbb52649e59a03d6627ccd2387ebddcd6624719e9f16
+      sha256: a768fc8ede5f0c8e6150476e14f38e2417c0864ca36bb4582be8e21925a03c22
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.6"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1434,10 +1434,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
+      sha256: b89e6e24d1454e149ab20fbb225af58660f0c0bf4475544650700d8e2da54aef
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.1"
+    version: "5.11.0"
   window_manager:
     dependency: transitive
     description:
@@ -1797,5 +1797,5 @@ packages:
     source: hosted
     version: "1.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
Fixes #237

## Summary by Sourcery

This pull request fixes a bug where the raw markdown page was missing a title bar on macOS. It also improves the performance of the history page by using a simple Text widget instead of a ListenBuilder with an RNode for displaying the title, and by using a single RNode instance for history updates instead of multiple instances.

Bug Fixes:
- Fixes an issue where the raw markdown page was missing a title bar on macOS.

Enhancements:
- The history list items now use a simple Text widget instead of a ListenBuilder with an RNode for displaying the title, improving performance.
- The app now uses a single RNode instance for history updates instead of multiple instances, reducing memory usage and improving performance.