### PR TITLE
fix: some models can't produce title

### DIFF
--- a/lib/core/util/chat_title.dart
+++ b/lib/core/util/chat_title.dart
@@ -1,3 +1,5 @@
+import 'package:gpt_box/data/res/openai.dart';
+
 abstract final class ChatTitleUtil {
   static const _maxLen = 20;
 
@@ -40,5 +42,36 @@ $userCotentLocator''';
     }
 
     return title;
+  }
+
+  /// Get the suitable model for generating title.
+  static String? get pickSuitableModel {
+    final cfgPromptModel = Cfg.current.genTitleModel;
+    if (cfgPromptModel != null && cfgPromptModel.isNotEmpty) {
+      return cfgPromptModel;
+    }
+
+    // Auto select
+    final models = Cfg.models.value;
+    if (models == null || models.isEmpty) return null;
+
+    const preferedModels = [
+      'deepseek-chat',
+      'deepseek-v3',
+      'gpt-4o-mini',
+      'claude-3.5-sonnet',
+      'claude-3-5-sonnet',
+      'gemini-2.0-flash',
+      'gpt-3.5-turbo',
+    ];
+
+    for (final pModel in preferedModels) {
+      for (final model in models) {
+        // Some third-party reverse api providers names the model with a prefix...
+        if (model.contains(pModel)) return model;
+      }
+    }
+
+    return Cfg.current.model;
   }
 }

--- a/lib/data/model/chat/config.dart
+++ b/lib/data/model/chat/config.dart
@@ -29,6 +29,8 @@ final class ChatConfig {
   final String name;
   @HiveField(14)
   final String? genTitlePrompt;
+  @HiveField(15)
+  final String? genTitleModel;
 
   const ChatConfig({
     required this.prompt,
@@ -39,6 +41,7 @@ final class ChatConfig {
     required this.id,
     required this.name,
     this.genTitlePrompt,
+    this.genTitleModel,
   });
 
   ChatConfig.noid({
@@ -49,6 +52,7 @@ final class ChatConfig {
     required this.historyLen,
     required this.name,
     this.genTitlePrompt,
+    this.genTitleModel,
   }) : id = shortid.generate();
 
   static final apiUrlReg = RegExp(r'^https?://[0-9A-Za-z\.]+(:\d+)?$');

--- a/lib/data/model/chat/config.g.dart
+++ b/lib/data/model/chat/config.g.dart
@@ -26,13 +26,14 @@ class ChatConfigAdapter extends TypeAdapter<ChatConfig> {
       id: fields[8] == null ? 'defaultId' : fields[8] as String,
       name: fields[9] == null ? '' : fields[9] as String,
       genTitlePrompt: fields[14] as String?,
+      genTitleModel: fields[15] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, ChatConfig obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.prompt)
       ..writeByte(1)
@@ -48,7 +49,9 @@ class ChatConfigAdapter extends TypeAdapter<ChatConfig> {
       ..writeByte(9)
       ..write(obj.name)
       ..writeByte(14)
-      ..write(obj.genTitlePrompt);
+      ..write(obj.genTitlePrompt)
+      ..writeByte(15)
+      ..write(obj.genTitleModel);
   }
 
   @override
@@ -75,6 +78,7 @@ ChatConfig _$ChatConfigFromJson(Map<String, dynamic> json) => ChatConfig(
       id: json['id'] as String? ?? 'defaultId',
       name: json['name'] as String,
       genTitlePrompt: json['genTitlePrompt'] as String?,
+      genTitleModel: json['genTitleModel'] as String?,
     );
 
 Map<String, dynamic> _$ChatConfigToJson(ChatConfig instance) =>
@@ -87,4 +91,5 @@ Map<String, dynamic> _$ChatConfigToJson(ChatConfig instance) =>
       'id': instance.id,
       'name': instance.name,
       'genTitlePrompt': instance.genTitlePrompt,
+      'genTitleModel': instance.genTitleModel,
     };

--- a/lib/data/model/chat/history/history.g.dart
+++ b/lib/data/model/chat/history/history.g.dart
@@ -286,22 +286,13 @@ ChatHistory _$ChatHistoryFromJson(Map<String, dynamic> json) => ChatHistory(
           : ChatSettings.fromJson(json['settings'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$ChatHistoryToJson(ChatHistory instance) {
-  final val = <String, dynamic>{
-    'id': instance.id,
-    'items': instance.items,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('settings', instance.settings);
-  return val;
-}
+Map<String, dynamic> _$ChatHistoryToJson(ChatHistory instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'items': instance.items,
+      if (instance.name case final value?) 'name': value,
+      if (instance.settings case final value?) 'settings': value,
+    };
 
 ChatHistoryItem _$ChatHistoryItemFromJson(Map<String, dynamic> json) =>
     ChatHistoryItem(
@@ -318,24 +309,15 @@ ChatHistoryItem _$ChatHistoryItemFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$ChatHistoryItemToJson(ChatHistoryItem instance) {
-  final val = <String, dynamic>{
-    'role': _$ChatRoleEnumMap[instance.role]!,
-    'content': instance.content,
-    'createdAt': instance.createdAt.toIso8601String(),
-    'id': instance.id,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('toolCallId', instance.toolCallId);
-  writeNotNull('toolCalls', instance.toolCalls);
-  return val;
-}
+Map<String, dynamic> _$ChatHistoryItemToJson(ChatHistoryItem instance) =>
+    <String, dynamic>{
+      'role': _$ChatRoleEnumMap[instance.role]!,
+      'content': instance.content,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'id': instance.id,
+      if (instance.toolCallId case final value?) 'toolCallId': value,
+      if (instance.toolCalls case final value?) 'toolCalls': value,
+    };
 
 const _$ChatRoleEnumMap = {
   ChatRole.user: 'user',

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -72,8 +72,7 @@ import 'l10n_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -81,8 +80,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -94,8 +92,7 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -924,8 +921,7 @@ abstract class AppLocalizations {
   String get wrap;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -934,69 +930,44 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-        'de',
-        'en',
-        'es',
-        'fr',
-        'id',
-        'ja',
-        'nl',
-        'pt',
-        'ru',
-        'tr',
-        'uk',
-        'zh'
-      ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'fr', 'id', 'ja', 'nl', 'pt', 'ru', 'tr', 'uk', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'zh':
-      {
-        switch (locale.countryCode) {
-          case 'TW':
-            return AppLocalizationsZhTw();
-        }
-        break;
-      }
+    case 'zh': {
+  switch (locale.countryCode) {
+    case 'TW': return AppLocalizationsZhTw();
+   }
+  break;
+   }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de':
-      return AppLocalizationsDe();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'id':
-      return AppLocalizationsId();
-    case 'ja':
-      return AppLocalizationsJa();
-    case 'nl':
-      return AppLocalizationsNl();
-    case 'pt':
-      return AppLocalizationsPt();
-    case 'ru':
-      return AppLocalizationsRu();
-    case 'tr':
-      return AppLocalizationsTr();
-    case 'uk':
-      return AppLocalizationsUk();
-    case 'zh':
-      return AppLocalizationsZh();
+    case 'de': return AppLocalizationsDe();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'fr': return AppLocalizationsFr();
+    case 'id': return AppLocalizationsId();
+    case 'ja': return AppLocalizationsJa();
+    case 'nl': return AppLocalizationsNl();
+    case 'pt': return AppLocalizationsPt();
+    case 'ru': return AppLocalizationsRu();
+    case 'tr': return AppLocalizationsTr();
+    case 'uk': return AppLocalizationsUk();
+    case 'zh': return AppLocalizationsZh();
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
 }

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -9,8 +9,7 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Ähnlich wie https://api.openai.com/v1 (mit dem abschließenden /v1). Soll diese URL weiterhin verwendet werden?';
+  String get apiUrlV1Tip => 'Ähnlich wie https://api.openai.com/v1 (mit dem abschließenden /v1). Soll diese URL weiterhin verwendet werden?';
 
   @override
   String get assistant => 'Assistent';
@@ -34,8 +33,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoScrollBottom => 'Automatisch nach unten scrollen';
 
   @override
-  String get backupTip =>
-      'Bitte stellen Sie sicher, dass Ihre Sicherungsdatei privat und sicher ist!';
+  String get backupTip => 'Bitte stellen Sie sicher, dass Ihre Sicherungsdatei privat und sicher ist!';
 
   @override
   String get balance => 'Guthaben';
@@ -44,8 +42,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get calcTokenLen => 'Token-Länge berechnen';
 
   @override
-  String get changeModelTip =>
-      'Verschiedene Schlüssel können möglicherweise auf unterschiedliche Modelllisten zugreifen. Wenn Sie den Mechanismus nicht verstehen und Fehler auftreten, empfiehlt es sich, das Modell neu einzustellen.';
+  String get changeModelTip => 'Verschiedene Schlüssel können möglicherweise auf unterschiedliche Modelllisten zugreifen. Wenn Sie den Mechanismus nicht verstehen und Fehler auftreten, empfiehlt es sich, das Modell neu einzustellen.';
 
   @override
   String get chat => 'Chat';
@@ -118,8 +115,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get emptyTrash => 'Papierkorb leeren';
 
   @override
-  String get emptyTrashTip =>
-      '==0, beim nächsten Start löschen. <0 nicht automatisch löschen.';
+  String get emptyTrashTip => '==0, beim nächsten Start löschen. <0 nicht automatisch löschen.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get headTailMode => 'Kopf-Schwanz-Modus';
 
   @override
-  String get headTailModeTip =>
-      'Sendet nur `Prompt + erste Benutzernachricht + aktuelle Eingabe` als Kontext.\n\nDies ist besonders nützlich für die Übersetzung von Gesprächen (spart Tokens).';
+  String get headTailModeTip => 'Sendet nur `Prompt + erste Benutzernachricht + aktuelle Eingabe` als Kontext.\n\nDies ist besonders nützlich für die Übersetzung von Gesprächen (spart Tokens).';
 
   @override
   String get help => 'Hilfe';
@@ -230,8 +225,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get message => 'Nachricht';
 
   @override
-  String get migrationV1UrlTip =>
-      'Soll \"/v1\" automatisch am Ende der Konfiguration hinzugefügt werden?';
+  String get migrationV1UrlTip => 'Soll \"/v1\" automatisch am Ende der Konfiguration hinzugefügt werden?';
 
   @override
   String get minute => 'Minute';
@@ -240,8 +234,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get model => 'Modell';
 
   @override
-  String get modelRegExpTip =>
-      'Wenn der Modellname übereinstimmt, werden Tools verwendet';
+  String get modelRegExpTip => 'Wenn der Modellname übereinstimmt, werden Tools verwendet';
 
   @override
   String get more => 'Mehr';
@@ -276,8 +269,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get onSwitchChat => 'Beim Wechseln der Konversation';
 
   @override
-  String get onlyRestoreHistory =>
-      'Nur Chat-Verlauf wiederherstellen (API-URL und geheimer Schlüssel werden nicht wiederhergestellt)';
+  String get onlyRestoreHistory => 'Nur Chat-Verlauf wiederherstellen (API-URL und geheimer Schlüssel werden nicht wiederhergestellt)';
 
   @override
   String get onlySyncOnLaunch => 'Nur beim Start synchronisieren';
@@ -304,8 +296,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip =>
-      'Öffnen Sie diesen Link auf einem anderen Gerät, um die aktuelle Konfiguration schnell zu importieren.';
+  String get quickShareTip => 'Öffnen Sie diesen Link auf einem anderen Gerät, um die aktuelle Konfiguration schnell zu importieren.';
 
   @override
   String get raw => 'Roh';
@@ -326,8 +317,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get replay => 'Wiederholen';
 
   @override
-  String get replayTip =>
-      'Die wiederholten Nachrichten und alle folgenden Nachrichten werden gelöscht.';
+  String get replayTip => 'Die wiederholten Nachrichten und alle folgenden Nachrichten werden gelöscht.';
 
   @override
   String get res => 'Ressource';
@@ -355,8 +345,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get saveErrChat => 'Fehlerhaften Chat speichern';
 
   @override
-  String get saveErrChatTip =>
-      'Speichern Sie nach dem Empfangen/Senden jeder Nachricht, auch wenn Fehler auftreten';
+  String get saveErrChatTip => 'Speichern Sie nach dem Empfangen/Senden jeder Nachricht, auch wenn Fehler auftreten';
 
   @override
   String get scrollSwitchChat => 'Scrollen zum Wechseln des Chats';
@@ -374,8 +363,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareFrom => 'Geteilt von';
 
   @override
-  String get skipSameTitle =>
-      'Chats mit demselben Titel wie lokale Chats überspringen';
+  String get skipSameTitle => 'Chats mit demselben Titel wie lokale Chats überspringen';
 
   @override
   String get softWrap => 'Zeilenumbruch';

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -9,8 +9,7 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Similar to https://api.openai.com/v1 (requiring the final /v1). Continue using this URL?';
+  String get apiUrlV1Tip => 'Similar to https://api.openai.com/v1 (requiring the final /v1). Continue using this URL?';
 
   @override
   String get assistant => 'Assistant';
@@ -43,8 +42,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calcTokenLen => 'Calculate tokens length';
 
   @override
-  String get changeModelTip =>
-      'Different keys may be able to access different lists of models, so if you don\'t understand the mechanism and get an error, it is recommended to reset the model.';
+  String get changeModelTip => 'Different keys may be able to access different lists of models, so if you don\'t understand the mechanism and get an error, it is recommended to reset the model.';
 
   @override
   String get chat => 'Chat';
@@ -117,8 +115,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emptyTrash => 'Empty recycle bin';
 
   @override
-  String get emptyTrashTip =>
-      '==0, delete on next startup. <0 do not delete automatically.';
+  String get emptyTrashTip => '==0, delete on next startup. <0 do not delete automatically.';
 
   @override
   String fileNotFound(Object file) {
@@ -152,8 +149,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get headTailMode => 'Head-Tail';
 
   @override
-  String get headTailModeTip =>
-      'Only send `prompt + first user message + current input` as the context. \n\nThis is useful for translating as it saves tokens.';
+  String get headTailModeTip => 'Only send `prompt + first user message + current input` as the context. \n\nThis is useful for translating as it saves tokens.';
 
   @override
   String get help => 'Help';
@@ -229,8 +225,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get message => 'Message';
 
   @override
-  String get migrationV1UrlTip =>
-      'Should \"/v1\" be automatically added to the end of the configuration?';
+  String get migrationV1UrlTip => 'Should \"/v1\" be automatically added to the end of the configuration?';
 
   @override
   String get minute => 'min';
@@ -274,8 +269,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onSwitchChat => 'When switching conversations';
 
   @override
-  String get onlyRestoreHistory =>
-      'Only restore histories (exclude api url / secret key)';
+  String get onlyRestoreHistory => 'Only restore histories (exclude api url / secret key)';
 
   @override
   String get onlySyncOnLaunch => 'Only sync on launch';
@@ -302,8 +296,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip =>
-      'Open this link on another device to quickly import the current configuration.';
+  String get quickShareTip => 'Open this link on another device to quickly import the current configuration.';
 
   @override
   String get raw => 'Raw';
@@ -324,8 +317,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get replay => 'Replay';
 
   @override
-  String get replayTip =>
-      'The replayed messages and all subsequent messages will be cleared.';
+  String get replayTip => 'The replayed messages and all subsequent messages will be cleared.';
 
   @override
   String get res => 'Resource';
@@ -353,8 +345,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveErrChat => 'Save chat with errors';
 
   @override
-  String get saveErrChatTip =>
-      'Save the chat after each message sent or received even if it has error.';
+  String get saveErrChatTip => 'Save the chat after each message sent or received even if it has error.';
 
   @override
   String get scrollSwitchChat => 'Scroll to switch chat';
@@ -372,8 +363,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareFrom => 'Share from';
 
   @override
-  String get skipSameTitle =>
-      'Skip chats with titles that are the same as local chats.';
+  String get skipSameTitle => 'Skip chats with titles that are the same as local chats.';
 
   @override
   String get softWrap => 'Soft wrap';

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -9,8 +9,7 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Similar a https://api.openai.com/v1 (requiriendo el /v1 final). ¿Continuar usando esta URL?';
+  String get apiUrlV1Tip => 'Similar a https://api.openai.com/v1 (requiriendo el /v1 final). ¿Continuar usando esta URL?';
 
   @override
   String get assistant => 'Asistente';
@@ -34,8 +33,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoScrollBottom => 'Desplazamiento automático hacia abajo';
 
   @override
-  String get backupTip =>
-      '¡Por favor, asegúrese de que su archivo de respaldo sea privado y seguro!';
+  String get backupTip => '¡Por favor, asegúrese de que su archivo de respaldo sea privado y seguro!';
 
   @override
   String get balance => 'Saldo';
@@ -44,8 +42,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get calcTokenLen => 'Calcular longitud de tokens';
 
   @override
-  String get changeModelTip =>
-      'Diferentes claves pueden acceder a diferentes listas de modelos. Si no entiendes el mecanismo y ocurren errores, se recomienda reconfigurar el modelo.';
+  String get changeModelTip => 'Diferentes claves pueden acceder a diferentes listas de modelos. Si no entiendes el mecanismo y ocurren errores, se recomienda reconfigurar el modelo.';
 
   @override
   String get chat => 'Chat';
@@ -118,8 +115,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get emptyTrash => 'Vaciar la papelera de reciclaje';
 
   @override
-  String get emptyTrashTip =>
-      '==0, eliminar en el próximo inicio. <0 no eliminar automáticamente.';
+  String get emptyTrashTip => '==0, eliminar en el próximo inicio. <0 no eliminar automáticamente.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get headTailMode => 'Modo cabeza-cola';
 
   @override
-  String get headTailModeTip =>
-      'Solo envía `prompt + primer mensaje del usuario + entrada actual` como contexto.\n\nEsto es especialmente útil para traducir conversaciones (ahorra tokens).';
+  String get headTailModeTip => 'Solo envía `prompt + primer mensaje del usuario + entrada actual` como contexto.\n\nEsto es especialmente útil para traducir conversaciones (ahorra tokens).';
 
   @override
   String get help => 'Ayuda';
@@ -174,8 +169,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get hour => 'hora';
 
   @override
-  String get httpToolTip =>
-      'Realizar una solicitud HTTP, por ejemplo: buscar contenido';
+  String get httpToolTip => 'Realizar una solicitud HTTP, por ejemplo: buscar contenido';
 
   @override
   String get ignoreContextConstraint => 'Ignorar restricción de contexto';
@@ -231,8 +225,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get message => 'Mensaje';
 
   @override
-  String get migrationV1UrlTip =>
-      '¿Se debe agregar automáticamente \"/v1\" al final de la configuración?';
+  String get migrationV1UrlTip => '¿Se debe agregar automáticamente \"/v1\" al final de la configuración?';
 
   @override
   String get minute => 'minuto';
@@ -241,8 +234,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get model => 'Modelo';
 
   @override
-  String get modelRegExpTip =>
-      'Si el nombre del modelo coincide, se usarán las herramientas';
+  String get modelRegExpTip => 'Si el nombre del modelo coincide, se usarán las herramientas';
 
   @override
   String get more => 'Más';
@@ -254,8 +246,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get myOtherApps => 'Mis otras aplicaciones';
 
   @override
-  String get needOpenAIKey =>
-      'Por favor, introduzca primero la clave de OpenAI';
+  String get needOpenAIKey => 'Por favor, introduzca primero la clave de OpenAI';
 
   @override
   String get needRestart => 'Se necesita reiniciar para aplicar';
@@ -278,8 +269,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onSwitchChat => 'Al cambiar de conversación';
 
   @override
-  String get onlyRestoreHistory =>
-      'Solo restaurar historial de chat (no restaurar URL de API ni clave secreta)';
+  String get onlyRestoreHistory => 'Solo restaurar historial de chat (no restaurar URL de API ni clave secreta)';
 
   @override
   String get onlySyncOnLaunch => 'Sincronizar solo al iniciar';
@@ -306,8 +296,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get promptsSettingsItem => 'Indicaciones';
 
   @override
-  String get quickShareTip =>
-      'Abre este enlace en otro dispositivo para importar rápidamente la configuración actual.';
+  String get quickShareTip => 'Abre este enlace en otro dispositivo para importar rápidamente la configuración actual.';
 
   @override
   String get raw => 'Crudo';
@@ -328,8 +317,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get replay => 'Repetir';
 
   @override
-  String get replayTip =>
-      'Los mensajes reproducidos y todos los mensajes posteriores se borrarán.';
+  String get replayTip => 'Los mensajes reproducidos y todos los mensajes posteriores se borrarán.';
 
   @override
   String get res => 'Recurso';
@@ -357,8 +345,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get saveErrChat => 'Guardar chat con error';
 
   @override
-  String get saveErrChatTip =>
-      'Guardar después de recibir/enviar cada mensaje, incluso si hay errores';
+  String get saveErrChatTip => 'Guardar después de recibir/enviar cada mensaje, incluso si hay errores';
 
   @override
   String get scrollSwitchChat => 'Desplazar para cambiar de chat';
@@ -376,8 +363,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareFrom => 'Compartido desde';
 
   @override
-  String get skipSameTitle =>
-      'Omitir chats con el mismo título que los chats locales';
+  String get skipSameTitle => 'Omitir chats con el mismo título que los chats locales';
 
   @override
   String get softWrap => 'Ajuste de línea';

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -9,8 +9,7 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Similaire à https://api.openai.com/v1 (nécessitant le /v1 final). Continuer à utiliser cette URL ?';
+  String get apiUrlV1Tip => 'Similaire à https://api.openai.com/v1 (nécessitant le /v1 final). Continuer à utiliser cette URL ?';
 
   @override
   String get assistant => 'Assistant';
@@ -34,8 +33,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoScrollBottom => 'Défilement automatique vers le bas';
 
   @override
-  String get backupTip =>
-      'Assurez-vous que votre fichier de sauvegarde est privé et sécurisé !';
+  String get backupTip => 'Assurez-vous que votre fichier de sauvegarde est privé et sécurisé !';
 
   @override
   String get balance => 'Solde';
@@ -44,8 +42,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get calcTokenLen => 'Calculer la longueur des tokens';
 
   @override
-  String get changeModelTip =>
-      'Différentes clés peuvent accéder à différentes listes de modèles. Si vous ne comprenez pas le mécanisme et que des erreurs surviennent, il est recommandé de reconfigurer le modèle.';
+  String get changeModelTip => 'Différentes clés peuvent accéder à différentes listes de modèles. Si vous ne comprenez pas le mécanisme et que des erreurs surviennent, il est recommandé de reconfigurer le modèle.';
 
   @override
   String get chat => 'Chat';
@@ -118,8 +115,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get emptyTrash => 'Vider la corbeille';
 
   @override
-  String get emptyTrashTip =>
-      '==0, supprimer au prochain démarrage. <0 ne pas supprimer automatiquement.';
+  String get emptyTrashTip => '==0, supprimer au prochain démarrage. <0 ne pas supprimer automatiquement.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get headTailMode => 'Mode tête-queue';
 
   @override
-  String get headTailModeTip =>
-      'Envoie seulement `prompt + premier message utilisateur + entrée actuelle` comme contexte.\n\nCeci est particulièrement utile pour traduire des conversations (économise des tokens).';
+  String get headTailModeTip => 'Envoie seulement `prompt + premier message utilisateur + entrée actuelle` comme contexte.\n\nCeci est particulièrement utile pour traduire des conversations (économise des tokens).';
 
   @override
   String get help => 'Aide';
@@ -174,8 +169,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get hour => 'heure';
 
   @override
-  String get httpToolTip =>
-      'Effectuer une requête HTTP, par exemple : rechercher du contenu';
+  String get httpToolTip => 'Effectuer une requête HTTP, par exemple : rechercher du contenu';
 
   @override
   String get ignoreContextConstraint => 'Ignorer la contrainte de contexte';
@@ -231,8 +225,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get message => 'Message';
 
   @override
-  String get migrationV1UrlTip =>
-      'Faut-il ajouter automatiquement \"/v1\" à la fin de la configuration ?';
+  String get migrationV1UrlTip => 'Faut-il ajouter automatiquement \"/v1\" à la fin de la configuration ?';
 
   @override
   String get minute => 'minute';
@@ -241,8 +234,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get model => 'Modèle';
 
   @override
-  String get modelRegExpTip =>
-      'Si le nom du modèle correspond, les outils seront utilisés';
+  String get modelRegExpTip => 'Si le nom du modèle correspond, les outils seront utilisés';
 
   @override
   String get more => 'Plus';
@@ -277,8 +269,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onSwitchChat => 'Lors du changement de conversation';
 
   @override
-  String get onlyRestoreHistory =>
-      'Restaurer uniquement l\'historique des chats (ne pas restaurer l\'URL de l\'API et la clé secrète)';
+  String get onlyRestoreHistory => 'Restaurer uniquement l\'historique des chats (ne pas restaurer l\'URL de l\'API et la clé secrète)';
 
   @override
   String get onlySyncOnLaunch => 'Synchroniser uniquement au lancement';
@@ -305,8 +296,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get promptsSettingsItem => 'Invites';
 
   @override
-  String get quickShareTip =>
-      'Ouvrez ce lien sur un autre appareil pour importer rapidement la configuration actuelle.';
+  String get quickShareTip => 'Ouvrez ce lien sur un autre appareil pour importer rapidement la configuration actuelle.';
 
   @override
   String get raw => 'Brut';
@@ -327,8 +317,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get replay => 'Rejouer';
 
   @override
-  String get replayTip =>
-      'Les messages rejoués et tous les messages suivants seront effacés.';
+  String get replayTip => 'Les messages rejoués et tous les messages suivants seront effacés.';
 
   @override
   String get res => 'Ressource';
@@ -356,8 +345,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get saveErrChat => 'Enregistrer le chat avec erreur';
 
   @override
-  String get saveErrChatTip =>
-      'Enregistrer après réception/envoi de chaque message, même s\'il y a des erreurs';
+  String get saveErrChatTip => 'Enregistrer après réception/envoi de chaque message, même s\'il y a des erreurs';
 
   @override
   String get scrollSwitchChat => 'Faire défiler pour changer de chat';
@@ -375,8 +363,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareFrom => 'Partagé depuis';
 
   @override
-  String get skipSameTitle =>
-      'Ignorer les chats avec le même titre que les chats locaux';
+  String get skipSameTitle => 'Ignorer les chats avec le même titre que les chats locaux';
 
   @override
   String get softWrap => 'Retour à la ligne automatique';

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -9,8 +9,7 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Mirip dengan https://api.openai.com/v1 (memerlukan /v1 di akhir). Lanjutkan menggunakan URL ini?';
+  String get apiUrlV1Tip => 'Mirip dengan https://api.openai.com/v1 (memerlukan /v1 di akhir). Lanjutkan menggunakan URL ini?';
 
   @override
   String get assistant => 'Asisten';
@@ -34,8 +33,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get autoScrollBottom => 'Gulir ke bawah secara otomatis';
 
   @override
-  String get backupTip =>
-      'Pastikan file cadangan Anda bersifat pribadi dan aman!';
+  String get backupTip => 'Pastikan file cadangan Anda bersifat pribadi dan aman!';
 
   @override
   String get balance => 'Saldo';
@@ -44,8 +42,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get calcTokenLen => 'Hitung panjang Token';
 
   @override
-  String get changeModelTip =>
-      'Kunci yang berbeda mungkin dapat mengakses daftar model yang berbeda. Jika Anda tidak memahami mekanismenya dan terjadi kesalahan, disarankan untuk mengatur ulang model.';
+  String get changeModelTip => 'Kunci yang berbeda mungkin dapat mengakses daftar model yang berbeda. Jika Anda tidak memahami mekanismenya dan terjadi kesalahan, disarankan untuk mengatur ulang model.';
 
   @override
   String get chat => 'Obrolan';
@@ -118,8 +115,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get emptyTrash => 'Kosongkan tempat sampah';
 
   @override
-  String get emptyTrashTip =>
-      '==0, hapus saat mulai berikutnya. <0 jangan hapus secara otomatis.';
+  String get emptyTrashTip => '==0, hapus saat mulai berikutnya. <0 jangan hapus secara otomatis.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get headTailMode => 'Mode kepala-ekor';
 
   @override
-  String get headTailModeTip =>
-      'Hanya mengirim `prompt + pesan pengguna pertama + input saat ini` sebagai konteks.\n\nIni sangat berguna saat menerjemahkan percakapan (menghemat token).';
+  String get headTailModeTip => 'Hanya mengirim `prompt + pesan pengguna pertama + input saat ini` sebagai konteks.\n\nIni sangat berguna saat menerjemahkan percakapan (menghemat token).';
 
   @override
   String get help => 'Bantuan';
@@ -230,8 +225,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get message => 'Pesan';
 
   @override
-  String get migrationV1UrlTip =>
-      'Haruskah \"/v1\" ditambahkan secara otomatis di akhir konfigurasi?';
+  String get migrationV1UrlTip => 'Haruskah \"/v1\" ditambahkan secara otomatis di akhir konfigurasi?';
 
   @override
   String get minute => 'menit';
@@ -275,8 +269,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get onSwitchChat => 'Saat beralih percakapan';
 
   @override
-  String get onlyRestoreHistory =>
-      'Hanya pulihkan riwayat obrolan (tidak memulihkan URL API dan Kunci Rahasia)';
+  String get onlyRestoreHistory => 'Hanya pulihkan riwayat obrolan (tidak memulihkan URL API dan Kunci Rahasia)';
 
   @override
   String get onlySyncOnLaunch => 'Hanya sinkronkan saat peluncuran';
@@ -303,8 +296,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get promptsSettingsItem => 'Prompt';
 
   @override
-  String get quickShareTip =>
-      'Buka tautan ini di perangkat lain untuk dengan cepat mengimpor konfigurasi saat ini.';
+  String get quickShareTip => 'Buka tautan ini di perangkat lain untuk dengan cepat mengimpor konfigurasi saat ini.';
 
   @override
   String get raw => 'Mentah';
@@ -325,8 +317,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get replay => 'Putar ulang';
 
   @override
-  String get replayTip =>
-      'Pesan yang diputar ulang dan semua pesan selanjutnya akan dihapus.';
+  String get replayTip => 'Pesan yang diputar ulang dan semua pesan selanjutnya akan dihapus.';
 
   @override
   String get res => 'Sumber daya';
@@ -354,8 +345,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get saveErrChat => 'Simpan obrolan error';
 
   @override
-  String get saveErrChatTip =>
-      'Simpan setelah menerima/mengirim setiap pesan, bahkan jika ada kesalahan';
+  String get saveErrChatTip => 'Simpan setelah menerima/mengirim setiap pesan, bahkan jika ada kesalahan';
 
   @override
   String get scrollSwitchChat => 'Gulir untuk beralih obrolan';
@@ -373,8 +363,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareFrom => 'Dibagikan dari';
 
   @override
-  String get skipSameTitle =>
-      'Lewati obrolan dengan judul yang sama dengan obrolan lokal';
+  String get skipSameTitle => 'Lewati obrolan dengan judul yang sama dengan obrolan lokal';
 
   @override
   String get softWrap => 'Pembungkus lunak';

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -9,8 +9,7 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'https://api.openai.com/v1に似ています（最後の /v1 が必要）。このURLを引き続き使用しますか？';
+  String get apiUrlV1Tip => 'https://api.openai.com/v1に似ています（最後の /v1 が必要）。このURLを引き続き使用しますか？';
 
   @override
   String get assistant => 'アシスタント';
@@ -43,8 +42,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get calcTokenLen => 'トークン長を計算';
 
   @override
-  String get changeModelTip =>
-      '異なるキーで利用可能なモデルリストが異なる場合があります。メカニズムがわからない場合やエラーが発生する場合は、モデルを再設定することをお勧めします。';
+  String get changeModelTip => '異なるキーで利用可能なモデルリストが異なる場合があります。メカニズムがわからない場合やエラーが発生する場合は、モデルを再設定することをお勧めします。';
 
   @override
   String get chat => 'チャット';
@@ -151,8 +149,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get headTailMode => 'ヘッドテールモード';
 
   @override
-  String get headTailModeTip =>
-      '`プロンプト+最初のユーザーメッセージ+現在の入力`のみをコンテキストとして送信します。\n\nこれは会話の翻訳に特に有用です（トークンを節約できます）。';
+  String get headTailModeTip => '`プロンプト+最初のユーザーメッセージ+現在の入力`のみをコンテキストとして送信します。\n\nこれは会話の翻訳に特に有用です（トークンを節約できます）。';
 
   @override
   String get help => 'ヘルプ';

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -9,8 +9,7 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Vergelijkbaar met https://api.openai.com/v1 (met de laatste /v1 vereist). Doorgaan met het gebruik van deze URL?';
+  String get apiUrlV1Tip => 'Vergelijkbaar met https://api.openai.com/v1 (met de laatste /v1 vereist). Doorgaan met het gebruik van deze URL?';
 
   @override
   String get assistant => 'Assistent';
@@ -34,8 +33,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoScrollBottom => 'Automatisch naar beneden scrollen';
 
   @override
-  String get backupTip =>
-      'Zorg ervoor dat uw back-upbestand privé en veilig is!';
+  String get backupTip => 'Zorg ervoor dat uw back-upbestand privé en veilig is!';
 
   @override
   String get balance => 'Saldo';
@@ -44,8 +42,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get calcTokenLen => 'Tokenlengte berekenen';
 
   @override
-  String get changeModelTip =>
-      'Verschillende sleutels kunnen toegang hebben tot verschillende modellijsten. Als u het mechanisme niet begrijpt en er fouten optreden, is het raadzaam om het model opnieuw in te stellen.';
+  String get changeModelTip => 'Verschillende sleutels kunnen toegang hebben tot verschillende modellijsten. Als u het mechanisme niet begrijpt en er fouten optreden, is het raadzaam om het model opnieuw in te stellen.';
 
   @override
   String get chat => 'Chat';
@@ -118,8 +115,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get emptyTrash => 'Prullenbak leegmaken';
 
   @override
-  String get emptyTrashTip =>
-      '==0, bij de volgende start verwijderen. <0 niet automatisch verwijderen.';
+  String get emptyTrashTip => '==0, bij de volgende start verwijderen. <0 niet automatisch verwijderen.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get headTailMode => 'Kop-staart modus';
 
   @override
-  String get headTailModeTip =>
-      'Stuurt alleen `prompt + eerste gebruikersbericht + huidige invoer` als context.\n\nDit is vooral handig voor het vertalen van gesprekken (bespaart tokens).';
+  String get headTailModeTip => 'Stuurt alleen `prompt + eerste gebruikersbericht + huidige invoer` als context.\n\nDit is vooral handig voor het vertalen van gesprekken (bespaart tokens).';
 
   @override
   String get help => 'Help';
@@ -174,8 +169,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get hour => 'uur';
 
   @override
-  String get httpToolTip =>
-      'HTTP-verzoek uitvoeren, bijvoorbeeld: inhoud zoeken';
+  String get httpToolTip => 'HTTP-verzoek uitvoeren, bijvoorbeeld: inhoud zoeken';
 
   @override
   String get ignoreContextConstraint => 'Contextbeperking negeren';
@@ -231,8 +225,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get message => 'Bericht';
 
   @override
-  String get migrationV1UrlTip =>
-      'Moet \"/v1\" automatisch worden toegevoegd aan het einde van de configuratie?';
+  String get migrationV1UrlTip => 'Moet \"/v1\" automatisch worden toegevoegd aan het einde van de configuratie?';
 
   @override
   String get minute => 'minuut';
@@ -241,8 +234,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get model => 'Model';
 
   @override
-  String get modelRegExpTip =>
-      'Als de modelnaam overeenkomt, worden tools gebruikt';
+  String get modelRegExpTip => 'Als de modelnaam overeenkomt, worden tools gebruikt';
 
   @override
   String get more => 'Meer';
@@ -277,8 +269,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onSwitchChat => 'Bij het wisselen van gesprekken';
 
   @override
-  String get onlyRestoreHistory =>
-      'Alleen chatgeschiedenis herstellen (API-URL en geheime sleutel niet herstellen)';
+  String get onlyRestoreHistory => 'Alleen chatgeschiedenis herstellen (API-URL en geheime sleutel niet herstellen)';
 
   @override
   String get onlySyncOnLaunch => 'Alleen synchroniseren bij opstarten';
@@ -305,8 +296,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip =>
-      'Open deze link op een ander apparaat om de huidige configuratie snel te importeren.';
+  String get quickShareTip => 'Open deze link op een ander apparaat om de huidige configuratie snel te importeren.';
 
   @override
   String get raw => 'Onbewerkt';
@@ -327,8 +317,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get replay => 'Herhalen';
 
   @override
-  String get replayTip =>
-      'De herhaalde berichten en alle volgende berichten worden gewist.';
+  String get replayTip => 'De herhaalde berichten en alle volgende berichten worden gewist.';
 
   @override
   String get res => 'Bron';
@@ -356,8 +345,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get saveErrChat => 'Foutieve chat opslaan';
 
   @override
-  String get saveErrChatTip =>
-      'Opslaan na ontvangen/verzenden van elk bericht, zelfs als er fouten zijn';
+  String get saveErrChatTip => 'Opslaan na ontvangen/verzenden van elk bericht, zelfs als er fouten zijn';
 
   @override
   String get scrollSwitchChat => 'Scrollen om van chat te wisselen';
@@ -375,8 +363,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareFrom => 'Gedeeld van';
 
   @override
-  String get skipSameTitle =>
-      'Chats met dezelfde titel als lokale chats overslaan';
+  String get skipSameTitle => 'Chats met dezelfde titel als lokale chats overslaan';
 
   @override
   String get softWrap => 'Zachte terugloop';

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -9,8 +9,7 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Semelhante a https://api.openai.com/v1 (requerendo o /v1 final). Continuar usando esta URL?';
+  String get apiUrlV1Tip => 'Semelhante a https://api.openai.com/v1 (requerendo o /v1 final). Continuar usando esta URL?';
 
   @override
   String get assistant => 'Assistente';
@@ -34,8 +33,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoScrollBottom => 'Rolar automaticamente para baixo';
 
   @override
-  String get backupTip =>
-      'Por favor, certifique-se de que seu arquivo de backup é privado e seguro!';
+  String get backupTip => 'Por favor, certifique-se de que seu arquivo de backup é privado e seguro!';
 
   @override
   String get balance => 'Saldo';
@@ -44,8 +42,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get calcTokenLen => 'Calcular comprimento dos tokens';
 
   @override
-  String get changeModelTip =>
-      'Diferentes chaves podem acessar diferentes listas de modelos. Se você não entende o mecanismo e ocorrem erros, é recomendável reconfigurar o modelo.';
+  String get changeModelTip => 'Diferentes chaves podem acessar diferentes listas de modelos. Se você não entende o mecanismo e ocorrem erros, é recomendável reconfigurar o modelo.';
 
   @override
   String get chat => 'Chat';
@@ -118,8 +115,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get emptyTrash => 'Esvaziar a lixeira';
 
   @override
-  String get emptyTrashTip =>
-      '==0, excluir na próxima inicialização. <0 não excluir automaticamente.';
+  String get emptyTrashTip => '==0, excluir na próxima inicialização. <0 não excluir automaticamente.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get headTailMode => 'Modo cabeça-cauda';
 
   @override
-  String get headTailModeTip =>
-      'Envia apenas `prompt + primeira mensagem do usuário + entrada atual` como contexto.\n\nIsso é especialmente útil para traduzir conversas (economiza tokens).';
+  String get headTailModeTip => 'Envia apenas `prompt + primeira mensagem do usuário + entrada atual` como contexto.\n\nIsso é especialmente útil para traduzir conversas (economiza tokens).';
 
   @override
   String get help => 'Ajuda';
@@ -174,8 +169,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get hour => 'hora';
 
   @override
-  String get httpToolTip =>
-      'Realizar uma solicitação HTTP, por exemplo: pesquisar conteúdo';
+  String get httpToolTip => 'Realizar uma solicitação HTTP, por exemplo: pesquisar conteúdo';
 
   @override
   String get ignoreContextConstraint => 'Ignorar restrição de contexto';
@@ -231,8 +225,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get message => 'Mensagem';
 
   @override
-  String get migrationV1UrlTip =>
-      'Deve-se adicionar automaticamente \"/v1\" ao final da configuração?';
+  String get migrationV1UrlTip => 'Deve-se adicionar automaticamente \"/v1\" ao final da configuração?';
 
   @override
   String get minute => 'minuto';
@@ -241,8 +234,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get model => 'Modelo';
 
   @override
-  String get modelRegExpTip =>
-      'Se o nome do modelo corresponder, as ferramentas serão usadas';
+  String get modelRegExpTip => 'Se o nome do modelo corresponder, as ferramentas serão usadas';
 
   @override
   String get more => 'Mais';
@@ -277,8 +269,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onSwitchChat => 'Ao alternar conversas';
 
   @override
-  String get onlyRestoreHistory =>
-      'Restaurar apenas o histórico de chat (não restaurar URL da API e chave secreta)';
+  String get onlyRestoreHistory => 'Restaurar apenas o histórico de chat (não restaurar URL da API e chave secreta)';
 
   @override
   String get onlySyncOnLaunch => 'Sincronizar apenas na inicialização';
@@ -305,8 +296,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get promptsSettingsItem => 'Prompts';
 
   @override
-  String get quickShareTip =>
-      'Abra este link em outro dispositivo para importar rapidamente a configuração atual.';
+  String get quickShareTip => 'Abra este link em outro dispositivo para importar rapidamente a configuração atual.';
 
   @override
   String get raw => 'Bruto';
@@ -327,8 +317,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get replay => 'Repetir';
 
   @override
-  String get replayTip =>
-      'As mensagens reproduzidas e todas as mensagens subsequentes serão apagadas.';
+  String get replayTip => 'As mensagens reproduzidas e todas as mensagens subsequentes serão apagadas.';
 
   @override
   String get res => 'Recurso';
@@ -356,8 +345,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get saveErrChat => 'Salvar chat com erro';
 
   @override
-  String get saveErrChatTip =>
-      'Salvar após receber/enviar cada mensagem, mesmo se houver erros';
+  String get saveErrChatTip => 'Salvar após receber/enviar cada mensagem, mesmo se houver erros';
 
   @override
   String get scrollSwitchChat => 'Rolar para alternar chat';
@@ -375,8 +363,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareFrom => 'Compartilhado de';
 
   @override
-  String get skipSameTitle =>
-      'Pular chats com o mesmo título que os chats locais';
+  String get skipSameTitle => 'Pular chats com o mesmo título que os chats locais';
 
   @override
   String get softWrap => 'Quebra de linha suave';

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -9,8 +9,7 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Похоже на https://api.openai.com/v1 (требуется конечный /v1). Продолжить использование этого URL?';
+  String get apiUrlV1Tip => 'Похоже на https://api.openai.com/v1 (требуется конечный /v1). Продолжить использование этого URL?';
 
   @override
   String get assistant => 'Ассистент';
@@ -34,8 +33,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoScrollBottom => 'Автоматическая прокрутка вниз';
 
   @override
-  String get backupTip =>
-      'Пожалуйста, убедитесь, что ваш файл резервной копии является приватным и безопасным!';
+  String get backupTip => 'Пожалуйста, убедитесь, что ваш файл резервной копии является приватным и безопасным!';
 
   @override
   String get balance => 'Баланс';
@@ -44,8 +42,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get calcTokenLen => 'Рассчитать длину токенов';
 
   @override
-  String get changeModelTip =>
-      'Разные ключи могут иметь доступ к разным спискам моделей. Если вы не понимаете механизм и возникают ошибки, рекомендуется переустановить модель.';
+  String get changeModelTip => 'Разные ключи могут иметь доступ к разным спискам моделей. Если вы не понимаете механизм и возникают ошибки, рекомендуется переустановить модель.';
 
   @override
   String get chat => 'Чат';
@@ -118,8 +115,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get emptyTrash => 'Очистить корзину';
 
   @override
-  String get emptyTrashTip =>
-      '==0, удалить при следующем запуске. <0 не удалять автоматически.';
+  String get emptyTrashTip => '==0, удалить при следующем запуске. <0 не удалять автоматически.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get headTailMode => 'Режим начало-конец';
 
   @override
-  String get headTailModeTip =>
-      'Отправляет только `подсказку + первое сообщение пользователя + текущий ввод` в качестве контекста.\n\nЭто особенно полезно для перевода разговоров (экономит токены).';
+  String get headTailModeTip => 'Отправляет только `подсказку + первое сообщение пользователя + текущий ввод` в качестве контекста.\n\nЭто особенно полезно для перевода разговоров (экономит токены).';
 
   @override
   String get help => 'Помощь';
@@ -230,8 +225,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get message => 'Сообщение';
 
   @override
-  String get migrationV1UrlTip =>
-      'Следует ли автоматически добавлять \"/v1\" в конец конфигурации?';
+  String get migrationV1UrlTip => 'Следует ли автоматически добавлять \"/v1\" в конец конфигурации?';
 
   @override
   String get minute => 'минута';
@@ -240,8 +234,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get model => 'Модель';
 
   @override
-  String get modelRegExpTip =>
-      'Если имя модели совпадает, будут использованы инструменты';
+  String get modelRegExpTip => 'Если имя модели совпадает, будут использованы инструменты';
 
   @override
   String get more => 'Больше';
@@ -276,8 +269,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onSwitchChat => 'При переключении разговора';
 
   @override
-  String get onlyRestoreHistory =>
-      'Восстановить только историю чатов (не восстанавливать URL API и секретный ключ)';
+  String get onlyRestoreHistory => 'Восстановить только историю чатов (не восстанавливать URL API и секретный ключ)';
 
   @override
   String get onlySyncOnLaunch => 'Синхронизировать только при запуске';
@@ -304,8 +296,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get promptsSettingsItem => 'Подсказки';
 
   @override
-  String get quickShareTip =>
-      'Откройте эту ссылку на другом устройстве, чтобы быстро импортировать текущую конфигурацию.';
+  String get quickShareTip => 'Откройте эту ссылку на другом устройстве, чтобы быстро импортировать текущую конфигурацию.';
 
   @override
   String get raw => 'Необработанный';
@@ -326,8 +317,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get replay => 'Повтор';
 
   @override
-  String get replayTip =>
-      'Воспроизведенные сообщения и все последующие сообщения будут удалены.';
+  String get replayTip => 'Воспроизведенные сообщения и все последующие сообщения будут удалены.';
 
   @override
   String get res => 'Ресурс';
@@ -355,8 +345,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get saveErrChat => 'Сохранить чат с ошибкой';
 
   @override
-  String get saveErrChatTip =>
-      'Сохранять после получения/отправки каждого сообщения, даже если есть ошибки';
+  String get saveErrChatTip => 'Сохранять после получения/отправки каждого сообщения, даже если есть ошибки';
 
   @override
   String get scrollSwitchChat => 'Прокрутка для переключения чата';
@@ -374,8 +363,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get shareFrom => 'Поделился';
 
   @override
-  String get skipSameTitle =>
-      'Пропустить чаты с тем же заголовком, что и у локальных чатов';
+  String get skipSameTitle => 'Пропустить чаты с тем же заголовком, что и у локальных чатов';
 
   @override
   String get softWrap => 'Мягкий перенос';

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -9,8 +9,7 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'https://api.openai.com/v1 gibi (sondaki /v1 gerekli). Bu URL\'yi kullanmaya devam edilsin mi?';
+  String get apiUrlV1Tip => 'https://api.openai.com/v1 gibi (sondaki /v1 gerekli). Bu URL\'yi kullanmaya devam edilsin mi?';
 
   @override
   String get assistant => 'Asistan';
@@ -34,8 +33,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get autoScrollBottom => 'Otomatik aşağı kaydır';
 
   @override
-  String get backupTip =>
-      'Lütfen yedekleme dosyanızın özel ve güvenli olduğundan emin olun!';
+  String get backupTip => 'Lütfen yedekleme dosyanızın özel ve güvenli olduğundan emin olun!';
 
   @override
   String get balance => 'Bakiye';
@@ -44,8 +42,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get calcTokenLen => 'Token uzunluğunu hesapla';
 
   @override
-  String get changeModelTip =>
-      'Farklı anahtarlar farklı model listelerine erişebilir. Mekanizmayı anlamıyorsanız ve hatalar oluşuyorsa, modeli yeniden ayarlamanız önerilir.';
+  String get changeModelTip => 'Farklı anahtarlar farklı model listelerine erişebilir. Mekanizmayı anlamıyorsanız ve hatalar oluşuyorsa, modeli yeniden ayarlamanız önerilir.';
 
   @override
   String get chat => 'Sohbet';
@@ -118,8 +115,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get emptyTrash => 'Geri dönüşüm kutusunu boşalt';
 
   @override
-  String get emptyTrashTip =>
-      '==0, bir sonraki başlangıçta sil. <0 otomatik olarak silme.';
+  String get emptyTrashTip => '==0, bir sonraki başlangıçta sil. <0 otomatik olarak silme.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get headTailMode => 'Baş-Kuyruk modu';
 
   @override
-  String get headTailModeTip =>
-      'Sadece `prompt + ilk kullanıcı mesajı + mevcut giriş` bağlam olarak gönderilir.\n\nBu özellikle konuşmaları çevirmek için kullanışlıdır (token tasarrufu sağlar).';
+  String get headTailModeTip => 'Sadece `prompt + ilk kullanıcı mesajı + mevcut giriş` bağlam olarak gönderilir.\n\nBu özellikle konuşmaları çevirmek için kullanışlıdır (token tasarrufu sağlar).';
 
   @override
   String get help => 'Yardım';
@@ -230,8 +225,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get message => 'Mesaj';
 
   @override
-  String get migrationV1UrlTip =>
-      'Yapılandırmanın sonuna otomatik olarak \"/v1\" eklensin mi?';
+  String get migrationV1UrlTip => 'Yapılandırmanın sonuna otomatik olarak \"/v1\" eklensin mi?';
 
   @override
   String get minute => 'dakika';
@@ -275,8 +269,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get onSwitchChat => 'Konuşmalar arasında geçiş yaparken';
 
   @override
-  String get onlyRestoreHistory =>
-      'Sadece sohbet geçmişini geri yükle (API URL\'sini ve gizli anahtarı geri yükleme)';
+  String get onlyRestoreHistory => 'Sadece sohbet geçmişini geri yükle (API URL\'sini ve gizli anahtarı geri yükleme)';
 
   @override
   String get onlySyncOnLaunch => 'Sadece başlatırken senkronize et';
@@ -303,8 +296,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get promptsSettingsItem => 'Komutlar';
 
   @override
-  String get quickShareTip =>
-      'Mevcut yapılandırmayı hızlıca içe aktarmak için bu bağlantıyı başka bir cihazda açın.';
+  String get quickShareTip => 'Mevcut yapılandırmayı hızlıca içe aktarmak için bu bağlantıyı başka bir cihazda açın.';
 
   @override
   String get raw => 'Ham';
@@ -325,8 +317,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get replay => 'Tekrar oynat';
 
   @override
-  String get replayTip =>
-      'Tekrar oynatılan mesajlar ve sonraki tüm mesajlar temizlenecek.';
+  String get replayTip => 'Tekrar oynatılan mesajlar ve sonraki tüm mesajlar temizlenecek.';
 
   @override
   String get res => 'Kaynak';
@@ -354,8 +345,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get saveErrChat => 'Hatalı sohbeti kaydet';
 
   @override
-  String get saveErrChatTip =>
-      'Her mesajı aldıktan/gönderdikten sonra kaydet, hata olsa bile';
+  String get saveErrChatTip => 'Her mesajı aldıktan/gönderdikten sonra kaydet, hata olsa bile';
 
   @override
   String get scrollSwitchChat => 'Sohbeti değiştirmek için kaydır';
@@ -373,8 +363,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareFrom => 'Paylaşan';
 
   @override
-  String get skipSameTitle =>
-      'Yerel sohbetlerle aynı başlığa sahip sohbetleri atla';
+  String get skipSameTitle => 'Yerel sohbetlerle aynı başlığa sahip sohbetleri atla';
 
   @override
   String get softWrap => 'Yumuşak kaydırma';

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -9,8 +9,7 @@ class AppLocalizationsUk extends AppLocalizations {
   AppLocalizationsUk([String locale = 'uk']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      'Схоже на https://api.openai.com/v1 (потрібен кінцевий /v1). Продовжити використання цього URL?';
+  String get apiUrlV1Tip => 'Схоже на https://api.openai.com/v1 (потрібен кінцевий /v1). Продовжити використання цього URL?';
 
   @override
   String get assistant => 'Асистент';
@@ -34,8 +33,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get autoScrollBottom => 'Автоматично прокручувати до низу';
 
   @override
-  String get backupTip =>
-      'Будь ласка, зберігайте резервну копію файлу в безпеці та приватності!';
+  String get backupTip => 'Будь ласка, зберігайте резервну копію файлу в безпеці та приватності!';
 
   @override
   String get balance => 'Баланс';
@@ -44,8 +42,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get calcTokenLen => 'Обчислити довжину токенів';
 
   @override
-  String get changeModelTip =>
-      'Різні ключі можуть мати доступ до різних списків моделей. Якщо ви не розумієте механізму і виникають помилки, рекомендується переналаштувати модель.';
+  String get changeModelTip => 'Різні ключі можуть мати доступ до різних списків моделей. Якщо ви не розумієте механізму і виникають помилки, рекомендується переналаштувати модель.';
 
   @override
   String get chat => 'Чат';
@@ -118,8 +115,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get emptyTrash => 'Очистити кошик';
 
   @override
-  String get emptyTrashTip =>
-      '==0, видалити під час наступного запуску. <0 не видаляти автоматично.';
+  String get emptyTrashTip => '==0, видалити під час наступного запуску. <0 не видаляти автоматично.';
 
   @override
   String fileNotFound(Object file) {
@@ -153,8 +149,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get headTailMode => 'Режим голова-хвіст';
 
   @override
-  String get headTailModeTip =>
-      'Надсилає лише підказку + перше повідомлення користувача + поточне введення як контекст.\n\nЦе особливо корисно при перекладі діалогів (може заощадити токени).';
+  String get headTailModeTip => 'Надсилає лише підказку + перше повідомлення користувача + поточне введення як контекст.\n\nЦе особливо корисно при перекладі діалогів (може заощадити токени).';
 
   @override
   String get help => 'Допомога';
@@ -230,8 +225,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get message => 'Повідомлення';
 
   @override
-  String get migrationV1UrlTip =>
-      'Автоматично додати \"/v1\" у кінці конфігурації?';
+  String get migrationV1UrlTip => 'Автоматично додати \"/v1\" у кінці конфігурації?';
 
   @override
   String get minute => 'Хвилина';
@@ -240,8 +234,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get model => 'Модель';
 
   @override
-  String get modelRegExpTip =>
-      'Якщо назва моделі відповідає, використовувати інструменти';
+  String get modelRegExpTip => 'Якщо назва моделі відповідає, використовувати інструменти';
 
   @override
   String get more => 'Більше';
@@ -276,8 +269,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get onSwitchChat => 'При перемиканні чату';
 
   @override
-  String get onlyRestoreHistory =>
-      'Відновити лише історію чатів (без відновлення API Url та Secret Key)';
+  String get onlyRestoreHistory => 'Відновити лише історію чатів (без відновлення API Url та Secret Key)';
 
   @override
   String get onlySyncOnLaunch => 'Синхронізувати лише при запуску';
@@ -304,8 +296,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get promptsSettingsItem => 'Підказки';
 
   @override
-  String get quickShareTip =>
-      'Відкрийте це посилання на іншому пристрої, щоб швидко імпортувати поточну конфігурацію.';
+  String get quickShareTip => 'Відкрийте це посилання на іншому пристрої, щоб швидко імпортувати поточну конфігурацію.';
 
   @override
   String get raw => 'Сирий';
@@ -354,12 +345,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get saveErrChat => 'Зберегти помилку чату';
 
   @override
-  String get saveErrChatTip =>
-      'Зберігати після отримання/відправлення кожного повідомлення, навіть якщо є помилки';
+  String get saveErrChatTip => 'Зберігати після отримання/відправлення кожного повідомлення, навіть якщо є помилки';
 
   @override
-  String get scrollSwitchChat =>
-      'Прокручування вгору-вниз для перемикання чатів';
+  String get scrollSwitchChat => 'Прокручування вгору-вниз для перемикання чатів';
 
   @override
   String get search => 'Пошук';
@@ -374,8 +363,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shareFrom => 'Поділитися з';
 
   @override
-  String get skipSameTitle =>
-      'Пропустити чати з такими ж заголовками, як у локальних';
+  String get skipSameTitle => 'Пропустити чати з такими ж заголовками, як у локальних';
 
   @override
   String get softWrap => 'М\'який перенос';

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -9,8 +9,7 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
-  String get apiUrlV1Tip =>
-      '类似 `https://api.openai.com/v1`（需要最后的 `/v1`）。继续使用该 URL 吗？';
+  String get apiUrlV1Tip => '类似 `https://api.openai.com/v1`（需要最后的 `/v1`）。继续使用该 URL 吗？';
 
   @override
   String get assistant => '助手';
@@ -150,8 +149,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get headTailMode => '头尾模式';
 
   @override
-  String get headTailModeTip =>
-      '仅发送 `提示词+第一条用户信息+当前输入` 作为上下文。\n\n这在用于翻译对话时特别有用（可以节省 tokens）。';
+  String get headTailModeTip => '仅发送 `提示词+第一条用户信息+当前输入` 作为上下文。\n\n这在用于翻译对话时特别有用（可以节省 tokens）。';
 
   @override
   String get help => '帮助';
@@ -449,11 +447,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
 class AppLocalizationsZhTw extends AppLocalizationsZh {
-  AppLocalizationsZhTw() : super('zh_TW');
+  AppLocalizationsZhTw(): super('zh_TW');
 
   @override
-  String get apiUrlV1Tip =>
-      '類似 https://api.openai.com/v1（需要最後的 /v1）。繼續使用該 URL 嗎？';
+  String get apiUrlV1Tip => '類似 https://api.openai.com/v1（需要最後的 /v1）。繼續使用該 URL 嗎？';
 
   @override
   String get assistant => '助手';
@@ -593,8 +590,7 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get headTailMode => '頭尾模式';
 
   @override
-  String get headTailModeTip =>
-      '僅發送 `提示詞+第一條用戶訊息+當前輸入` 作為上下文。\n\n這在用於翻譯對話時特別有用（可以節省 tokens）。';
+  String get headTailModeTip => '僅發送 `提示詞+第一條用戶訊息+當前輸入` 作為上下文。\n\n這在用於翻譯對話時特別有用（可以節省 tokens）。';
 
   @override
   String get help => '幫助';

--- a/lib/view/page/home/req.dart
+++ b/lib/view/page/home/req.dart
@@ -496,8 +496,9 @@ Completer<void>? _genChatTitle(
             .raw,
       ).toOpenAI(),
     ];
+    final model = ChatTitleUtil.pickSuitableModel ?? cfg.model;
     final req = CreateChatCompletionRequest(
-      model: ChatCompletionModel.modelId(cfg.model),
+      model: ChatCompletionModel.modelId(model),
       messages: msgs,
     );
     Cfg.client.createChatCompletion(request: req).then(


### PR DESCRIPTION
Fixes #239

## Summary by Sourcery

Addresses a problem where certain models failed to generate titles for chat histories. It introduces a mechanism to automatically select an appropriate model for title generation, falling back to the user-configured default model if necessary. Additionally, it allows users to specify a preferred model for title generation.

Bug Fixes:
- Fixes an issue where some models were unable to produce a title for chat histories.

Enhancements:
- Adds logic to automatically select a suitable model for generating chat titles based on availability and a list of preferred models.
- Allows users to configure a specific model to use for title generation.