### PR TITLE
fix: single line code block copy

### DIFF
--- a/lib/view/widget/code.dart
+++ b/lib/view/widget/code.dart
@@ -85,7 +85,7 @@ class CodeElementBuilder extends MarkdownElementBuilder {
         theme: _theme,
         textStyle: _textStyle.copyWith(fontSize: preferredStyle?.fontSize),
         tabSize: 4,
-        selectable: false,
+        selectable: true,
         padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
       );
     }
@@ -96,7 +96,7 @@ class CodeElementBuilder extends MarkdownElementBuilder {
       theme: _theme,
       textStyle: _textStyle.copyWith(fontSize: preferredStyle?.fontSize),
       tabSize: 4,
-      selectable: false,
+      selectable: true,
       padding: const EdgeInsets.symmetric(vertical: 7, horizontal: 11),
     );
 
@@ -136,7 +136,7 @@ class CodeElementBuilder extends MarkdownElementBuilder {
             icon: const Icon(
               MingCute.copy_2_fill,
               size: 15,
-              color: Color.fromARGB(117, 129, 129, 129),
+              color: Color.fromARGB(173, 188, 188, 188),
             ),
             onTap: () {
               onCopy?.call(element.textContent.trim());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "1c296cd268f486cabcc3930e9b93a8133169305f18d722916e675959a88f6d2c"
+      sha256: "068190d6c99c436287936ba5855af2e1fa78d8083ae65b4db6a281780da727ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.9"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -170,10 +170,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: "8b158ab94ec6913e480dc3f752418348b5ae099eb75868b5f4775f0572999c61"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.4"
   camera:
     dependency: transitive
     description:
@@ -186,10 +186,10 @@ packages:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: "7cc6adf1868bdcf4e63a56b24b41692dfbad2bec1cdceea451c77798f6a605c3"
+      sha256: afdea63d66cce01cee6d56443a9d62f10dd58678c403cec78affff6fb52c6482
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.13"
+    version: "0.6.14"
   camera_avfoundation:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: cloudflare_turnstile
-      sha256: c7f37c7327d3f03b528a2334a5131c352ce62a545254e557693227a207801dc7
+      sha256: d13cbec55a1c4916bca1d4dbd84fbe7b655ae35a264513750fdb8250486269e0
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.1"
   code_builder:
     dependency: transitive
     description:
@@ -355,10 +355,10 @@ packages:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: e485c7a39ff2b384fa1d7e09b4e25f755804de8384358049124830b04fc4f93a
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   encrypt:
     dependency: transitive
     description:
@@ -656,10 +656,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      sha256: "5a1e6fb2c0561958d7e4c33574674bda7b77caaca7a33b758876956f2902eea3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.24"
+    version: "2.0.27"
   flutter_svg:
     dependency: transitive
     description:
@@ -1719,10 +1719,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes #245

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where single-line code blocks were not selectable, preventing users from copying the code.